### PR TITLE
[fix]: Implement proper nested property display with visual indentation

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -39,8 +39,10 @@
       "Bash(cp:*)",
       "WebFetch(domain:developer.hashicorp.com)",
       "Bash(gh issue list:*)",
-      "Bash(gh issue view:*)"
+      "Bash(gh issue view:*)",
+      "mcp__devtools__*"
     ],
     "deny": []
-  }
+  },
+  "$schema": "https://json.schemastore.org/claude-code-settings.json"
 }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "permissions": {
     "allow": [
       "Bash(go build:*)",
@@ -40,9 +41,10 @@
       "WebFetch(domain:developer.hashicorp.com)",
       "Bash(gh issue list:*)",
       "Bash(gh issue view:*)",
-      "mcp__devtools__*"
+      "mcp__devtools__*",
+      "mcp__devtools__think",
+      "mcp__devtools__gemini-agent"
     ],
     "deny": []
-  },
-  "$schema": "https://json.schemastore.org/claude-code-settings.json"
+  }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.6] - 2025-08-02
+
+### Fixed
+- **Nested Property Display Improvements**:
+  - Fixed nested properties like tags to display with proper visual hierarchy and indentation instead of inline format
+  - Enhanced property change analysis to treat nested objects (tags, metadata, labels, config objects) as single grouped property changes
+  - Implemented cross-format compatible indentation using Unicode En spaces (U+2002) to ensure consistent visual spacing in table, markdown, HTML, and JSON outputs
+  - Updated property change formatter to detect complex nested values and apply appropriate nested formatting with visual indentation
+  - Enhanced nested map and array formatting with proper line breaks and hierarchical display structure
+
+### Changed
+- **Property Analysis Logic**:
+  - Modified `compareObjects` function in analyzer.go to identify and group nested object properties instead of splitting them into individual property changes
+  - Added `shouldTreatAsNestedObject` helper function to detect common nested property patterns (tags, metadata, labels, etc.)
+  - Updated property change formatter to use context-aware formatting with `formatValueWithContext` method
+  - Enhanced test expectations to match new nested property display format with proper indentation
+
+### Dependencies
+- **Go-Output Library**:
+  - Updated go-output dependency from v2.1.1 to v2.1.2 for improved nested content rendering support
+
 ## [1.1.5] - 2025-08-01
 
 ### Fixed

--- a/go.mod
+++ b/go.mod
@@ -11,8 +11,6 @@ require (
 	github.com/stretchr/testify v1.10.0
 )
 
-// replace github.com/ArjenSchwarz/go-output/v2 => ../go-output/v2
-
 require (
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -3,13 +3,15 @@ module github.com/ArjenSchwarz/strata
 go 1.24.5
 
 require (
-	github.com/ArjenSchwarz/go-output/v2 v2.1.1
+	github.com/ArjenSchwarz/go-output/v2 v2.1.2
 	github.com/hashicorp/terraform-json v0.25.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/viper v1.20.1
 	github.com/stretchr/testify v1.10.0
 )
+
+// replace github.com/ArjenSchwarz/go-output/v2 => ../go-output/v2
 
 require (
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/ArjenSchwarz/go-output/v2 v2.1.1 h1:wvElS+bxd4vHGzvrVeZ4WJLQeWIEDC+CuJT07TKirKY=
-github.com/ArjenSchwarz/go-output/v2 v2.1.1/go.mod h1:gnjnnjaCWFykQ+GvWOlgzqwjpbvgKPaYMQxsY/SLOUA=
+github.com/ArjenSchwarz/go-output/v2 v2.1.2 h1:887pu71ibUMNmwmj50hk5QPOaSm7qZGP3EKAeEfOCVI=
+github.com/ArjenSchwarz/go-output/v2 v2.1.2/go.mod h1:gnjnnjaCWFykQ+GvWOlgzqwjpbvgKPaYMQxsY/SLOUA=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=

--- a/lib/plan/analyzer_test.go
+++ b/lib/plan/analyzer_test.go
@@ -1910,7 +1910,7 @@ func TestCompareObjects(t *testing.T) {
 			after:             map[string]any{"tags": map[string]any{"env": "prod"}},
 			expectedChanges:   1,
 			expectedActions:   []string{"update"},
-			expectedNames:     []string{"env"},
+			expectedNames:     []string{"tags"},
 			expectedSensitive: []bool{false},
 		},
 		{
@@ -2477,11 +2477,11 @@ func TestCompareObjectsEnhanced(t *testing.T) {
 				"tags": map[string]any{"env": "prod"},
 			},
 			expected: []PropertyChange{{
-				Name:   "env",
-				Path:   []string{"tags", "env"},
+				Name:   "tags",
+				Path:   []string{"tags"},
 				Action: "update",
-				Before: "dev",
-				After:  "prod",
+				Before: map[string]any{"env": "dev"},
+				After:  map[string]any{"env": "prod"},
 			}},
 		},
 		{

--- a/lib/plan/formatter.go
+++ b/lib/plan/formatter.go
@@ -698,7 +698,13 @@ func (f *Formatter) formatNestedMap(v map[string]any, baseIndent string) string 
 	for _, key := range keys {
 		// Use Unicode En spaces for indentation (U+2002) - preserves spacing without HTML escaping issues
 		nextIndent := baseIndent + "\u2002\u2002\u2002\u2002"
-		value := f.formatValueWithContext(v[key], false, false, nextIndent)
+		// Check if the value is complex (map or slice) to handle nested structures properly
+		isValueNested := false
+		switch v[key].(type) {
+		case map[string]any, []any:
+			isValueNested = true
+		}
+		value := f.formatValueWithContext(v[key], false, isValueNested, nextIndent)
 		// Use Unicode En spaces for consistent indentation across all formats
 		lines = append(lines, fmt.Sprintf("%s\u2002\u2002\u2002\u2002%s = %s", baseIndent, key, value))
 	}
@@ -713,7 +719,13 @@ func (f *Formatter) formatNestedArray(v []any, baseIndent string) string {
 	for i, item := range v {
 		// Use Unicode En spaces for indentation (U+2002) - preserves spacing without HTML escaping issues
 		nextIndent := baseIndent + "\u2002\u2002"
-		value := f.formatValueWithContext(item, false, false, nextIndent)
+		// Check if the item is complex (map or slice) to handle nested structures properly
+		isItemNested := false
+		switch item.(type) {
+		case map[string]any, []any:
+			isItemNested = true
+		}
+		value := f.formatValueWithContext(item, false, isItemNested, nextIndent)
 		// Use Unicode En spaces for consistent indentation across all formats
 		lines = append(lines, fmt.Sprintf("%s\u2002\u2002[%d] = %s", baseIndent, i, value))
 	}

--- a/lib/plan/formatter_create_test.go
+++ b/lib/plan/formatter_create_test.go
@@ -79,10 +79,14 @@ func TestFormatterCreateActionDisplay(t *testing.T) {
 
 	// Verify the formatting
 	// For create actions, we should see the new values with + prefix
+	// Tags should now be displayed in nested format since they have multiple keys
 	expectedPatterns := []string{
 		"+ name = \"web-server-profile\"",
 		"+ path = \"/\"",
-		"+ tags = { Environment = \"production\", ManagedBy = \"terraform\" }",
+		"+ tags = {",
+		"\u2002\u2002\u2002\u2002Environment = \"production\"",
+		"\u2002\u2002\u2002\u2002ManagedBy = \"terraform\"",
+		"\u2002\u2002\u2002\u2002}",
 	}
 
 	for _, pattern := range expectedPatterns {


### PR DESCRIPTION
- Enhanced property change analysis to treat nested objects (tags, metadata, labels) as single grouped changes instead of splitting them into individual properties
- Implemented cross-format compatible indentation using Unicode En spaces (U+2002) for consistent visual spacing across table, markdown, HTML, and JSON outputs
- Added shouldTreatAsNestedObject helper function to detect common nested property patterns and group them appropriately
- Updated property change formatter with context-aware nested formatting including formatNestedMap and formatNestedArray methods
- Enhanced formatValueWithContext method to handle complex nested values with proper line breaks and hierarchical display
- Updated tests to expect new nested property display format with proper Unicode space indentation
- Updated go-output dependency from v2.1.1 to v2.1.2 for improved nested content rendering support

This fix resolves the issue where nested properties like tags were displayed inline instead of with proper visual hierarchy and indentation.