### PR TITLE
Fix T-280: Action Run Analysis Command Injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Action Argument Safety Regression Tests**: Added unit test coverage for `run_analysis` to validate safe argument handling for plan/config paths containing spaces and for plan files starting with `-`.
+
+### Fixed
+- **Action Command Construction Safety**: Updated `run_analysis` in `action.sh` to build and execute the Strata command as a Bash array (`"${cmd[@]}"`) and pass `--` before the plan file path, preventing argument splitting issues and option ambiguity for user-supplied paths.
+
 ## [1.5.0] - 2025-01-21
 
 ### Changed

--- a/action.sh
+++ b/action.sh
@@ -240,21 +240,21 @@ run_analysis() {
   local json_file="./strata-analysis.json"
 
   # Build command with all flags
-  local cmd="$TEMP_DIR/strata plan summary"
-  cmd="$cmd --output ${INPUT_OUTPUT_FORMAT:-markdown}"
-  cmd="$cmd --file $json_file --file-format json"
+  local cmd=("$TEMP_DIR/strata" "plan" "summary")
+  cmd+=("--output" "${INPUT_OUTPUT_FORMAT:-markdown}")
+  cmd+=("--file" "$json_file" "--file-format" "json")
 
-  [[ "${INPUT_SHOW_DETAILS:-false}" == "true" ]] && cmd="$cmd --details"
-  [[ "${INPUT_EXPAND_ALL:-false}" == "true" ]] && cmd="$cmd --expand-all"
-  [[ -n "${INPUT_CONFIG_FILE:-}" ]] && cmd="$cmd --config $INPUT_CONFIG_FILE"
+  [[ "${INPUT_SHOW_DETAILS:-false}" == "true" ]] && cmd+=("--details")
+  [[ "${INPUT_EXPAND_ALL:-false}" == "true" ]] && cmd+=("--expand-all")
+  [[ -n "${INPUT_CONFIG_FILE:-}" ]] && cmd+=("--config" "$INPUT_CONFIG_FILE")
 
-  cmd="$cmd $INPUT_PLAN_FILE"
+  cmd+=("--" "$INPUT_PLAN_FILE")
 
   echo "🔍 Analyzing Terraform plan"
-  echo "⚙️ Running: $cmd"
+  echo "⚙️ Running: ${cmd[*]}"
 
   # Execute and capture display output
-  if display_output=$($cmd 2>&1); then
+  if display_output=$("${cmd[@]}" 2>&1); then
     echo "✅ Analysis complete"
 
     # Store display output for GitHub integration

--- a/specs/bugfixes/action-run-analysis-command-injection/report.md
+++ b/specs/bugfixes/action-run-analysis-command-injection/report.md
@@ -1,0 +1,83 @@
+# Bugfix Report: Action run_analysis command injection
+
+**Date:** 2026-03-02
+**Status:** Fixed
+
+## Description of the Issue
+
+`action.sh` built the Strata invocation as one shell string and executed it with unquoted expansion. This caused shell word-splitting of file paths (for example paths containing spaces), and plan paths starting with `-` could be parsed as options.
+
+**Reproduction steps:**
+1. Set `INPUT_PLAN_FILE` and `INPUT_CONFIG_FILE` to values containing spaces.
+2. Run the action and reach `run_analysis`.
+3. Observe malformed argv handling and analysis failure.
+
+**Impact:** GitHub Action runs could fail or mis-handle user-provided file paths; argument safety was unreliable for untrusted inputs.
+
+## Investigation Summary
+
+Reviewed `action.sh` command construction and execution flow, then reproduced with a focused harness test in `test/action_test.sh`.
+
+- **Symptoms examined:** analysis failures for valid files when paths contain spaces or begin with `-`
+- **Code inspected:** `action.sh` `run_analysis`, existing action unit test coverage
+- **Hypotheses tested:** command string splitting versus array execution; end-of-options delimiter handling
+
+## Discovered Root Cause
+
+`run_analysis` concatenated all arguments into a single string (`cmd="..."`) and executed it as `$cmd`, which applies shell word splitting and does not preserve argument boundaries.
+
+**Defect type:** Missing input-safe command invocation (argument splitting bug).
+
+**Why it occurred:** command assembly used string concatenation instead of argv array semantics.
+
+**Contributing factors:** no explicit `--` delimiter before the plan-file positional argument.
+
+## Resolution for the Issue
+
+**Changes made:**
+- `action.sh:243-257` - switched from string command building to bash array (`cmd=(...)`, `cmd+=(...)`) and executed via `"${cmd[@]}"`; added `--` before `INPUT_PLAN_FILE`.
+- `test/action_test.sh:580-691` - added regression test `test_run_analysis_argument_safety` validating path-with-spaces and leading-dash plan file behavior using extracted `run_analysis` and a strict mock `strata` parser.
+
+**Approach rationale:** arrays preserve each argument exactly, preventing path splitting and ensuring option parsing stops before the plan path.
+
+**Alternatives considered:**
+- Escape individual values into a string with quoting helpers - rejected as brittle and easier to regress than native argv arrays.
+
+## Regression Test
+
+**Test file:** `test/action_test.sh`
+**Test name:** `test_run_analysis_argument_safety`
+
+**What it verifies:** `run_analysis` passes config/plan file paths as intact arguments, uses `--` before plan file, and supports plan paths beginning with `-`.
+
+**Run command:** `make test-action-unit`
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `action.sh` | Safe argv array command construction and execution in `run_analysis` |
+| `test/action_test.sh` | Added regression coverage for argument safety in `run_analysis` |
+| `specs/bugfixes/action-run-analysis-command-injection/report.md` | Bug investigation and fix documentation |
+
+## Verification
+
+**Automated:**
+- [x] Regression test passes
+- [x] Full test suite passes
+- [x] Linters/validators pass
+
+**Manual verification:**
+- `make run-sample SAMPLE=danger-sample.json`
+- `./strata plan summary nonexistent.tfplan` (confirmed non-zero error handling)
+
+## Prevention
+
+**Recommendations to avoid similar bugs:**
+- Build external commands as arrays, never concatenated strings.
+- Always insert `--` before positional user-supplied paths.
+- Keep regression coverage for shell argument safety in action unit tests.
+
+## Related
+
+- Transit ticket `T-280`

--- a/test/action_test.sh
+++ b/test/action_test.sh
@@ -577,6 +577,103 @@ test_dual_output_functions() {
     test_format_validation
 }
 
+# Test run_analysis argument handling for safety and spaces
+test_run_analysis_argument_safety() {
+    log_test "run_analysis argument safety"
+
+    local run_dir="$TEST_DIR/run_analysis_safety"
+    local temp_dir="$run_dir/temp"
+    local harness="$run_dir/run_analysis_harness.sh"
+    mkdir -p "$temp_dir"
+
+    cat > "$harness" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+
+ACTION_PATH="$1"
+TEST_TEMP_DIR="$2"
+PLAN_INPUT="$3"
+CONFIG_INPUT="$4"
+EXPECTED_PLAN="$5"
+EXPECTED_CONFIG="$6"
+
+cat > "$TEST_TEMP_DIR/strata" <<'MOCK'
+#!/bin/bash
+set -euo pipefail
+
+json_file=""
+config_file=""
+plan_file=""
+saw_separator="false"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    plan|summary) shift ;;
+    --output) shift 2 ;;
+    --file) json_file="$2"; shift 2 ;;
+    --file-format) shift 2 ;;
+    --details|--expand-all) shift ;;
+    --config) config_file="$2"; shift 2 ;;
+    --) saw_separator="true"; shift; plan_file="$1"; shift ;;
+    *) echo "unexpected-arg:$1" >&2; exit 99 ;;
+  esac
+done
+
+[[ "$saw_separator" == "true" ]] || { echo "missing -- separator" >&2; exit 98; }
+[[ "$plan_file" == "$EXPECTED_PLAN" ]] || { echo "plan mismatch: $plan_file" >&2; exit 97; }
+if [[ -n "$EXPECTED_CONFIG" ]]; then
+  [[ "$config_file" == "$EXPECTED_CONFIG" ]] || { echo "config mismatch: $config_file" >&2; exit 96; }
+fi
+
+cat > "$json_file" <<'JSON'
+{"statistics":{"total_changes":1,"dangerous_changes":0}}
+JSON
+echo "ok"
+MOCK
+chmod +x "$TEST_TEMP_DIR/strata"
+
+export EXPECTED_PLAN EXPECTED_CONFIG
+TEMP_DIR="$TEST_TEMP_DIR"
+INPUT_PLAN_FILE="$PLAN_INPUT"
+INPUT_OUTPUT_FORMAT="markdown"
+INPUT_SHOW_DETAILS="false"
+INPUT_EXPAND_ALL="false"
+INPUT_CONFIG_FILE="$CONFIG_INPUT"
+
+extract_outputs() { :; }
+set_default_outputs() { :; }
+
+eval "$(sed -n '/^run_analysis()/,/^}/p' "$ACTION_PATH")"
+run_analysis
+EOF
+    chmod +x "$harness"
+
+    local plan_with_spaces="$run_dir/plan with spaces.tfplan"
+    local config_with_spaces="$run_dir/config with spaces.yaml"
+    mkdir -p "$run_dir"
+    echo "plan" > "$plan_with_spaces"
+    echo "config" > "$config_with_spaces"
+
+    if bash "$harness" "action.sh" "$temp_dir" "$plan_with_spaces" "$config_with_spaces" "$plan_with_spaces" "$config_with_spaces" >/dev/null 2>&1; then
+        echo -e "${GREEN}[PASS]${NC} run_analysis should handle plan/config paths containing spaces"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        echo -e "${RED}[FAIL]${NC} run_analysis should handle plan/config paths containing spaces"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+
+    local dash_prefixed_plan="$run_dir/-dash-prefixed.tfplan"
+    echo "plan" > "$dash_prefixed_plan"
+
+    if bash "$harness" "action.sh" "$temp_dir" "$dash_prefixed_plan" "" "$dash_prefixed_plan" "" >/dev/null 2>&1; then
+        echo -e "${GREEN}[PASS]${NC} run_analysis should handle plan paths that start with '-'"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        echo -e "${RED}[FAIL]${NC} run_analysis should handle plan paths that start with '-'"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+}
+
 # Run all tests
 echo "Running GitHub Action Unit Tests..."
 echo "=================================="
@@ -591,6 +688,7 @@ test_cache_functionality
 test_environment_variables
 test_github_context
 test_dual_output_functions
+test_run_analysis_argument_safety
 
 # Print test summary
 echo ""


### PR DESCRIPTION
## Summary
- fix `action.sh` `run_analysis` to build command arguments as a bash array and execute with `"${cmd[@]}"`
- add `--` before the plan file argument so paths beginning with `-` are handled safely
- add regression tests for plan/config paths with spaces and leading-dash plan files
- add bugfix report at `specs/bugfixes/action-run-analysis-command-injection/report.md`

## Root cause
The action concatenated command and user-supplied file paths into one shell string and executed it with unquoted expansion, which broke argument boundaries for paths containing spaces and could mis-handle option-like path values.

## Validation
- make fmt
- make vet
- make test
- make test-action-unit
- make run-sample SAMPLE=danger-sample.json
- ./strata plan summary nonexistent.tfplan (expected failure)
