### PR TITLE
Fix T-111: Slice property removals in change analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Action Argument Safety Regression Tests**: Added unit test coverage for `run_analysis` to validate safe argument handling for plan/config paths containing spaces and for plan files starting with `-`.
 
 ### Fixed
+- **Property Change Analysis**: Fixed typed nil slice values being classified as "update" instead of "remove" in change analysis, ensuring list property removals are correctly detected regardless of Go nil representation.
 - **Action Command Construction Safety**: Updated `run_analysis` in `action.sh` to build and execute the Strata command as a Bash array (`"${cmd[@]}"`) and pass `--` before the plan file path, preventing argument splitting issues and option ambiguity for user-supplied paths.
 - Corrected output no-op detection so Terraform output `replace` actions are no longer misclassified as no-op when `before` and `after` values are equal.
 - Propagated `after_unknown` parent booleans for grouped nested objects even when `before` and `after` values are equal, so nested properties are correctly marked as unknown and shown as `(known after apply)`.

--- a/lib/plan/analyzer.go
+++ b/lib/plan/analyzer.go
@@ -352,7 +352,21 @@ func (a *Analyzer) compareObjects(path string, before, after, beforeSensitive, a
 				triggersReplacement = a.pathMatchesReplacePathString(propertyPath, replacePathStrings)
 			}
 
-			action := determineAction(processedBefore, processedAfter)
+			// Determine action: when afterSlice is nil (including typed nil
+			// []any), treat as removal. A typed nil []any does not compare
+			// equal to interface nil, so processedAfter-based detection in
+			// determineAction would incorrectly return "update".
+			var action string
+			switch {
+			case isUnknown:
+				action = actionUpdate
+			case !ok && after != nil:
+				// after is a non-slice type (e.g. string, bool) — type transition
+				action = actionUpdate
+			default:
+				// afterSlice is nil (untyped nil or typed nil []any) — removal
+				action = actionRemove
+			}
 			if shouldSkipEmptyValue(action, before, after) {
 				return
 			}

--- a/lib/plan/analyzer_utils_test.go
+++ b/lib/plan/analyzer_utils_test.go
@@ -953,6 +953,18 @@ func TestCompareObjectsEnhanced(t *testing.T) {
 			}},
 		},
 		{
+			name:   "typed nil slice removal",
+			before: map[string]any{"items": []any{1, 2}},
+			after:  map[string]any{"items": ([]any)(nil)},
+			expected: []PropertyChange{{
+				Name:   "items",
+				Path:   []string{"items"},
+				Action: "remove",
+				Before: []any{1, 2},
+				After:  ([]any)(nil),
+			}},
+		},
+		{
 			name:   "property removal",
 			before: map[string]any{"a": 1, "b": 2},
 			after:  map[string]any{"a": 1},


### PR DESCRIPTION
Fixes slice property removals being ignored in compareObjects when before is []any and after is nil/non-slice. Records remove/update changes for list removals, matching map removal handling.

- Added explicit action logic in the []any nil/non-slice branch
- Added regression test for typed nil slice removal
- All tests pass, linter clean