### PR TITLE
Fix T-184: File validator '..' substring blocking

### DIFF
--- a/config/validation.go
+++ b/config/validation.go
@@ -53,7 +53,11 @@ func (fv *FileValidator) sanitizeFilePath(path string) (string, error) {
 	}
 
 	// Reject URL-encoded traversal attempts (e.g. "..%2F", "..%252F")
-	if strings.Contains(path, "%") {
+	// Only target encoded separators and traversal patterns, not all '%' usage.
+	lowered := strings.ToLower(path)
+	if strings.Contains(lowered, "%2f") || strings.Contains(lowered, "%5c") ||
+		strings.Contains(lowered, "%252f") || strings.Contains(lowered, "%255c") ||
+		strings.Contains(lowered, "%2e") || strings.Contains(lowered, "%252e") {
 		return "", traversalErr
 	}
 

--- a/config/validation.go
+++ b/config/validation.go
@@ -45,20 +45,46 @@ func (fv *FileValidator) ValidateFileOutput(config *OutputConfiguration) error {
 // sanitizeFilePath cleans and validates a file path for security.
 // Returns the cleaned absolute path or a structured error for security violations.
 func (fv *FileValidator) sanitizeFilePath(path string) (string, error) {
-	// Check for path traversal attempts before cleaning
-	if strings.Contains(path, "..") {
-		return "", &FileOutputError{
-			Type:    "validation",
-			Code:    "PATH_TRAVERSAL",
-			Path:    path,
-			Message: "path traversal not allowed",
+	traversalErr := &FileOutputError{
+		Type:    "validation",
+		Code:    "PATH_TRAVERSAL",
+		Path:    path,
+		Message: "path traversal not allowed",
+	}
+
+	// Reject URL-encoded traversal attempts (e.g. "..%2F", "..%252F")
+	if strings.Contains(path, "%") {
+		return "", traversalErr
+	}
+
+	// Normalize: treat both / and \ as separators for cross-platform safety.
+	// This allows legitimate filenames like "report..json" while blocking
+	// directory traversal like "../secret" or "..\secret".
+	replacer := strings.NewReplacer("\\", "/")
+	normalized := replacer.Replace(path)
+	for _, part := range strings.Split(normalized, "/") {
+		if part == ".." {
+			return "", traversalErr
 		}
 	}
 
-	// Clean path and resolve any relative components
+	// Clean path and resolve any relative components.
+	// Re-check after cleaning since Clean collapses patterns like "....//".
 	clean := filepath.Clean(path)
+	cleanNorm := replacer.Replace(filepath.ToSlash(clean))
+	for _, part := range strings.Split(cleanNorm, "/") {
+		if part == ".." {
+			return "", traversalErr
+		}
+		// Reject components that are only dots (3+), as these can be
+		// obfuscated traversal attempts (e.g. "....//").
+		if len(part) > 2 && strings.Trim(part, ".") == "" {
+			return "", traversalErr
+		}
+	}
 
-	// Convert to absolute path for consistency
+	// Catch obfuscated traversal patterns (e.g. "....//") that survive cleaning
+	// by checking if the cleaned path escapes the working directory.
 	abs, err := filepath.Abs(clean)
 	if err != nil {
 		return "", &FileOutputError{
@@ -67,6 +93,15 @@ func (fv *FileValidator) sanitizeFilePath(path string) (string, error) {
 			Path:    path,
 			Message: "invalid file path",
 			Cause:   err,
+		}
+	}
+
+	// If the original path was relative, ensure the resolved path stays
+	// under the working directory (blocks obfuscated traversal like "....//").
+	if !filepath.IsAbs(path) {
+		wd, wdErr := os.Getwd()
+		if wdErr == nil && !strings.HasPrefix(abs, wd) {
+			return "", traversalErr
 		}
 	}
 

--- a/config/validation_file_test.go
+++ b/config/validation_file_test.go
@@ -316,6 +316,21 @@ func TestFileValidator_SanitizeFilePath(t *testing.T) {
 			path:    "reports//output.json",
 			wantErr: false,
 		},
+		{
+			name:    "double dots in filename",
+			path:    "report..json",
+			wantErr: false,
+		},
+		{
+			name:    "double dots in directory name",
+			path:    "versions/v1..2/output.json",
+			wantErr: false,
+		},
+		{
+			name:    "mid-path traversal",
+			path:    "reports/../../etc/passwd",
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/config/validation_file_test.go
+++ b/config/validation_file_test.go
@@ -331,6 +331,16 @@ func TestFileValidator_SanitizeFilePath(t *testing.T) {
 			path:    "reports/../../etc/passwd",
 			wantErr: true,
 		},
+		{
+			name:    "legitimate percent in filename",
+			path:    "reports/100%_complete.json",
+			wantErr: false,
+		},
+		{
+			name:    "percent sign in directory name",
+			path:    "100%done/output.json",
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Fixes FileValidator.sanitizeFilePath rejecting legitimate filenames containing '..' (e.g. report..json). Now only rejects '..' as a path component, not as a substring.

- Split path on separators and check for exact '..' components
- Added post-Clean re-check and encoded traversal protection
- Added tests for legitimate '..' filenames and traversal attacks
- All tests pass, linter clean