### PR TITLE
Fix T-235: Output config ignores flag defaults

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -68,26 +68,17 @@ type PlanConfig struct {
 
 // GetLCString returns a lowercase string value for the given setting
 func (config *Config) GetLCString(setting string) string {
-	if viper.IsSet(setting) {
-		return strings.ToLower(viper.GetString(setting))
-	}
-	return ""
+	return strings.ToLower(viper.GetString(setting))
 }
 
 // GetString returns a string value for the given setting
 func (config *Config) GetString(setting string) string {
-	if viper.IsSet(setting) {
-		return viper.GetString(setting)
-	}
-	return ""
+	return viper.GetString(setting)
 }
 
 // GetInt returns an integer value for the given setting
 func (config *Config) GetInt(setting string) int {
-	if viper.IsSet(setting) {
-		return viper.GetInt(setting)
-	}
-	return 0
+	return viper.GetInt(setting)
 }
 
 // OutputConfiguration holds the v2 output configuration settings

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -539,3 +539,40 @@ func TestGetDefaultConfig(t *testing.T) {
 		t.Errorf("Default config should be valid, got error: %v", err)
 	}
 }
+
+func TestGetString_ReturnsBoundFlagDefaults(t *testing.T) {
+	// Reset viper to simulate fresh state
+	viper.Reset()
+
+	// Simulate flag binding with a default value (as done in root.go)
+	// When a flag is bound but not explicitly set by the user,
+	// viper.IsSet() returns false but viper.GetString() returns the default.
+	viper.SetDefault("output", "table")
+	viper.SetDefault("table.style", "default")
+	viper.SetDefault("table.max-column-width", 50)
+
+	config := GetDefaultConfig()
+
+	// These should return the defaults, not empty/zero
+	if got := config.GetLCString("output"); got != "table" {
+		t.Errorf("GetLCString(\"output\") = %q, want %q", got, "table")
+	}
+	if got := config.GetString("table.style"); got != "default" {
+		t.Errorf("GetString(\"table.style\") = %q, want %q", got, "default")
+	}
+	if got := config.GetInt("table.max-column-width"); got != 50 {
+		t.Errorf("GetInt(\"table.max-column-width\") = %d, want %d", got, 50)
+	}
+
+	// NewOutputConfiguration should also reflect these defaults
+	outputConfig := config.NewOutputConfiguration()
+	if outputConfig.Format != "table" {
+		t.Errorf("OutputConfiguration.Format = %q, want %q", outputConfig.Format, "table")
+	}
+	if outputConfig.MaxColumnWidth != 50 {
+		t.Errorf("OutputConfiguration.MaxColumnWidth = %d, want %d", outputConfig.MaxColumnWidth, 50)
+	}
+
+	// Clean up
+	viper.Reset()
+}


### PR DESCRIPTION
Fixes config.GetString/GetLCString/GetInt returning empty values when viper.IsSet() is false. Removed the IsSet guard so viper's built-in precedence chain (explicit > config > flag default) works correctly.

- Simplified GetLCString, GetString, GetInt to return viper values unconditionally
- Added test verifying defaults flow through to NewOutputConfiguration
- All tests pass, linter clean