### PR TITLE
Fix T-351: Create output file when no changes

### DIFF
--- a/lib/plan/formatter.go
+++ b/lib/plan/formatter.go
@@ -104,7 +104,28 @@ func (f *Formatter) OutputSummary(summary *PlanSummary, outputConfig *config.Out
 			output.WithWriter(output.NewStdoutWriter()),
 		}
 		stdoutOut := output.NewOutput(stdoutOptions...)
-		return stdoutOut.Render(ctx, doc)
+		if err := stdoutOut.Render(ctx, doc); err != nil {
+			return fmt.Errorf("failed to render to stdout: %w", err)
+		}
+
+		// Render to file if configured (same as main code path)
+		if outputConfig.OutputFile != "" {
+			fileWriter, err := output.NewFileWriterWithOptions(".", outputConfig.OutputFile, output.WithAbsolutePaths())
+			if err != nil {
+				return fmt.Errorf("failed to create file writer: %w", err)
+			}
+			fileFormat := f.getFormatFromConfig(outputConfig.OutputFileFormat)
+			fileOptions := []output.OutputOption{
+				output.WithFormat(fileFormat),
+				output.WithWriter(fileWriter),
+			}
+			fileOut := output.NewOutput(fileOptions...)
+			if err := fileOut.Render(ctx, doc); err != nil {
+				return fmt.Errorf("failed to render to file: %w", err)
+			}
+		}
+
+		return nil
 	}
 
 	// Build the document using v2 builder pattern

--- a/lib/plan/formatter_no_changes_file_output_test.go
+++ b/lib/plan/formatter_no_changes_file_output_test.go
@@ -1,0 +1,43 @@
+package plan
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/ArjenSchwarz/strata/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestOutputSummary_NoChanges_CreatesOutputFile verifies that when a plan has no
+// resource or output changes, the output file is still created (T-351).
+func TestOutputSummary_NoChanges_CreatesOutputFile(t *testing.T) {
+	cfg := &config.Config{}
+	formatter := NewFormatter(cfg)
+
+	summary := &PlanSummary{
+		PlanFile:         "empty.tfplan",
+		TerraformVersion: "1.6.0",
+		Workspace:        "default",
+		Backend:          BackendInfo{Type: "local", Location: "terraform.tfstate"},
+		CreatedAt:        time.Now(),
+		Statistics:       ChangeStatistics{},
+		ResourceChanges:  []ResourceChange{},
+		OutputChanges:    []OutputChange{},
+	}
+
+	outputFile := filepath.Join(t.TempDir(), "no-changes.json")
+	outputConfig := &config.OutputConfiguration{
+		Format:           "json",
+		OutputFile:       outputFile,
+		OutputFileFormat: "json",
+	}
+
+	err := formatter.OutputSummary(summary, outputConfig, true)
+	require.NoError(t, err)
+
+	_, err = os.Stat(outputFile)
+	assert.NoError(t, err, "output file should be created even when plan has no changes")
+}


### PR DESCRIPTION
Fixes OutputSummary returning early when no changes, skipping file output. Now renders 'No changes detected' to both stdout and output file when --output-file is set.

- Added file output rendering in the no-changes early return block
- Added TestOutputSummary_NoChanges_CreatesOutputFile
- All tests pass, linter clean