### PR TITLE
Fix T-355: Surface plan load errors

### DIFF
--- a/cmd/plan_summary.go
+++ b/cmd/plan_summary.go
@@ -192,7 +192,10 @@ func runPlanSummary(cmd *cobra.Command, args []string) error {
 
 	// Create analyzer and generate summary
 	analyzer := plan.NewAnalyzer(tfPlan, cfg)
-	summary := analyzer.GenerateSummary(planFile)
+	summary, err := analyzer.GenerateSummary(planFile)
+	if err != nil {
+		return fmt.Errorf("failed to generate summary: %w", err)
+	}
 
 	// Create formatter and output summary
 	formatter := plan.NewFormatter(cfg)

--- a/lib/plan/analyzer.go
+++ b/lib/plan/analyzer.go
@@ -849,14 +849,14 @@ func (a *Analyzer) extractSensitiveIndex(sensitiveValues any, index int) any {
 }
 
 // GenerateSummary creates a comprehensive summary of the plan
-func (a *Analyzer) GenerateSummary(planFile string) *PlanSummary {
+func (a *Analyzer) GenerateSummary(planFile string) (*PlanSummary, error) {
 	parser := NewParser(planFile)
 
 	// Load the plan if not already loaded
 	if a.plan == nil {
 		plan, err := parser.LoadPlan()
 		if err != nil {
-			return nil
+			return nil, fmt.Errorf("failed to load plan: %w", err)
 		}
 		a.plan = plan
 	}
@@ -877,7 +877,7 @@ func (a *Analyzer) GenerateSummary(planFile string) *PlanSummary {
 	}
 
 	summary.Statistics = a.calculateStatistics(summary.ResourceChanges, summary.OutputChanges)
-	return summary
+	return summary, nil
 }
 
 // analyzeResourceChanges processes all resource changes in the plan

--- a/lib/plan/analyzer_outputs_test.go
+++ b/lib/plan/analyzer_outputs_test.go
@@ -840,7 +840,7 @@ func TestOutputsProcessingEndToEnd(t *testing.T) {
 			}
 
 			// Test integration with GenerateSummary
-			summary := analyzer.GenerateSummary("")
+			summary, _ := analyzer.GenerateSummary("")
 			assert.NotNil(t, summary, tc.description+" - summary should not be nil")
 			assert.Equal(t, tc.expectedOutputCount, len(summary.OutputChanges), tc.description+" - summary output count should match")
 
@@ -991,7 +991,7 @@ func TestOutputsIntegrationWithResourceChanges(t *testing.T) {
 			analyzer.plan = tc.plan
 
 			// Generate full summary
-			summary := analyzer.GenerateSummary("")
+			summary, _ := analyzer.GenerateSummary("")
 			assert.NotNil(t, summary, tc.description+" - summary should not be nil")
 
 			// Verify counts
@@ -1076,7 +1076,7 @@ func TestOutputsDisplayConsistencyAcrossFormats(t *testing.T) {
 
 	t.Run("outputs should maintain consistency in complete summary", func(t *testing.T) {
 		analyzer.plan = plan
-		summary := analyzer.GenerateSummary("")
+		summary, _ := analyzer.GenerateSummary("")
 
 		assert.NotNil(t, summary, "summary should not be nil")
 		assert.Len(t, summary.OutputChanges, 3, "summary should have 3 outputs")
@@ -1381,7 +1381,7 @@ func TestCompleteWorkflowWithUnknownValuesAndOutputsIntegration(t *testing.T) {
 			analyzer.plan = tc.plan
 
 			// Generate complete summary - this tests the full workflow
-			summary := analyzer.GenerateSummary("")
+			summary, _ := analyzer.GenerateSummary("")
 			assert.NotNil(t, summary, tc.description+" - summary should not be nil")
 
 			// Run comprehensive validation

--- a/lib/plan/analyzer_utils_test.go
+++ b/lib/plan/analyzer_utils_test.go
@@ -1734,7 +1734,7 @@ func TestCrossFormatConsistencyForUnknownValuesAndOutputs(t *testing.T) {
 	}
 
 	analyzer.plan = plan
-	summary := analyzer.GenerateSummary("")
+	summary, _ := analyzer.GenerateSummary("")
 
 	testCases := []struct {
 		name            string

--- a/lib/plan/comparison_consistency_test.go
+++ b/lib/plan/comparison_consistency_test.go
@@ -169,7 +169,7 @@ func TestComparisonConsistency_StandardizedDeepEqual(t *testing.T) {
 
 			cfg := &config.Config{}
 			analyzer := NewAnalyzer(plan, cfg)
-			summary := analyzer.GenerateSummary("test.json")
+			summary, _ := analyzer.GenerateSummary("test.json")
 
 			// If values are equal, we shouldn't see any property changes
 			// If values are different, we should see changes
@@ -287,7 +287,7 @@ func TestComparisonConsistency_SensitiveValueMasking(t *testing.T) {
 	}
 
 	analyzer := NewAnalyzer(plan, cfg)
-	summary := analyzer.GenerateSummary("test_sensitive.json")
+	summary, _ := analyzer.GenerateSummary("test_sensitive.json")
 
 	// Verify that sensitive comparisons are handled consistently
 	require.True(t, len(summary.ResourceChanges) > 0, "Should detect resource changes")

--- a/lib/plan/data_pipeline_integration_test.go
+++ b/lib/plan/data_pipeline_integration_test.go
@@ -44,7 +44,7 @@ func TestDataPipelineSortingOutputVerification(t *testing.T) {
 			}
 
 			analyzer := NewAnalyzer(plan, cfg)
-			summary := analyzer.GenerateSummary("")
+			summary, _ := analyzer.GenerateSummary("")
 			if summary == nil {
 				t.Fatalf("Failed to generate summary from plan file %s", sample)
 			}
@@ -92,7 +92,7 @@ func TestSortingWithinProviderGroups(t *testing.T) {
 	}
 
 	analyzer := NewAnalyzer(plan, cfg)
-	summary := analyzer.GenerateSummary("")
+	summary, _ := analyzer.GenerateSummary("")
 	if summary == nil {
 		t.Fatalf("Failed to generate summary from plan file %s", sample)
 	}
@@ -133,7 +133,7 @@ func TestAllOutputFormatsIdentical(t *testing.T) {
 	}
 
 	analyzer := NewAnalyzer(plan, cfg)
-	summary := analyzer.GenerateSummary("")
+	summary, _ := analyzer.GenerateSummary("")
 	if summary == nil {
 		t.Fatalf("Failed to generate summary from plan file %s", sample)
 	}
@@ -193,7 +193,7 @@ func TestAllSampleFiles(t *testing.T) {
 			}
 
 			analyzer := NewAnalyzer(plan, cfg)
-			summary := analyzer.GenerateSummary("")
+			summary, _ := analyzer.GenerateSummary("")
 			if summary == nil {
 				t.Fatalf("Failed to generate summary from plan file %s", sample)
 			}

--- a/lib/plan/error_handling_test.go
+++ b/lib/plan/error_handling_test.go
@@ -74,7 +74,7 @@ func TestMalformedTerraformPlans(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			planPath := filepath.Join(testDir, tt.filename)
-			summary := analyzer.GenerateSummary(planPath)
+			summary, _ := analyzer.GenerateSummary(planPath)
 
 			if tt.expectNil && summary != nil {
 				t.Errorf("Expected nil summary for %s, but got: %+v", tt.filename, summary)
@@ -189,7 +189,7 @@ func TestGracefulDegradation(t *testing.T) {
 	cfg := getErrorTestConfig()
 	analyzer := NewAnalyzer(nil, cfg)
 
-	summary := analyzer.GenerateSummary(testFile)
+	summary, _ := analyzer.GenerateSummary(testFile)
 	if summary == nil {
 		t.Skip("Error handling test failing due to plan generation issue - main functionality works")
 	}
@@ -292,7 +292,7 @@ func TestMemoryLimits(t *testing.T) {
 	cfg.Plan.PerformanceLimits.MaxTotalMemory = 10 * 1024   // 10KB total
 
 	analyzer := NewAnalyzer(nil, cfg)
-	summary := analyzer.GenerateSummary(testFile)
+	summary, _ := analyzer.GenerateSummary(testFile)
 
 	if summary == nil {
 		t.Fatal("Expected non-nil summary")
@@ -329,7 +329,7 @@ func TestUserFriendlyErrorMessages(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run("Path: "+testCase, func(t *testing.T) {
 			// Should not panic and should return nil gracefully
-			summary := analyzer.GenerateSummary(testCase)
+			summary, _ := analyzer.GenerateSummary(testCase)
 			if summary != nil {
 				t.Errorf("Expected nil summary for invalid path '%s', got: %+v", testCase, summary)
 			}

--- a/lib/plan/formatter_edge_cases_test.go
+++ b/lib/plan/formatter_edge_cases_test.go
@@ -1236,7 +1236,7 @@ func TestCrossFormatHeaderConsistency(t *testing.T) {
 
 	cfg := &config.Config{}
 	analyzer := NewAnalyzer(plan, cfg)
-	summary := analyzer.GenerateSummary("")
+	summary, _ := analyzer.GenerateSummary("")
 	formatter := NewFormatter(cfg)
 
 	// Test formats that support custom headers

--- a/lib/plan/integration_test.go
+++ b/lib/plan/integration_test.go
@@ -108,7 +108,7 @@ func TestEnhancedSummaryVisualization_EndToEnd(t *testing.T) {
 			analyzer := NewAnalyzer(nil, cfg) // Plan will be loaded internally
 
 			// Generate summary using the plan file path
-			summary := analyzer.GenerateSummary(planPath)
+			summary, _ := analyzer.GenerateSummary(planPath)
 			if summary == nil {
 				t.Fatalf("Failed to generate summary from plan file %s", tt.planFile)
 			}
@@ -180,7 +180,7 @@ func TestProviderGrouping_Integration(t *testing.T) {
 
 	// Create analyzer and generate summary
 	analyzer := NewAnalyzer(nil, cfg)
-	summary := analyzer.GenerateSummary(planPath)
+	summary, _ := analyzer.GenerateSummary(planPath)
 	if summary == nil {
 		t.Fatalf("Failed to generate summary from plan")
 	}
@@ -235,7 +235,7 @@ func TestCollapsibleFormatters_Integration(t *testing.T) {
 	// Test with expand-all disabled
 	cfg.ExpandAll = false
 	analyzer := NewAnalyzer(nil, cfg)
-	summary := analyzer.GenerateSummary(planPath)
+	summary, _ := analyzer.GenerateSummary(planPath)
 	if summary == nil {
 		t.Fatalf("Failed to generate summary")
 	}
@@ -284,7 +284,7 @@ func TestRiskAssessment_Integration(t *testing.T) {
 	}
 
 	analyzer := NewAnalyzer(nil, cfg)
-	summary := analyzer.GenerateSummary(planPath)
+	summary, _ := analyzer.GenerateSummary(planPath)
 	if summary == nil {
 		t.Fatalf("Failed to generate summary")
 	}
@@ -320,15 +320,21 @@ func TestErrorHandling_Integration(t *testing.T) {
 	analyzer := NewAnalyzer(nil, cfg)
 
 	// Test with non-existent file
-	summary := analyzer.GenerateSummary("non-existent-file.json")
+	summary, err := analyzer.GenerateSummary("non-existent-file.json")
 	if summary != nil {
 		t.Error("Expected nil summary for non-existent file")
 	}
+	if err == nil {
+		t.Error("Expected error for non-existent file")
+	}
 
 	// Test with empty file path
-	summary = analyzer.GenerateSummary("")
+	summary, err = analyzer.GenerateSummary("")
 	if summary != nil {
 		t.Error("Expected nil summary for empty file path")
+	}
+	if err == nil {
+		t.Error("Expected error for empty file path")
 	}
 }
 

--- a/lib/plan/output_improvements_integration_test.go
+++ b/lib/plan/output_improvements_integration_test.go
@@ -136,7 +136,7 @@ func TestPlanSummaryOutputImprovements_EndToEnd(t *testing.T) {
 			}
 
 			analyzer := NewAnalyzer(plan, cfg)
-			summary := analyzer.GenerateSummary("")
+			summary, _ := analyzer.GenerateSummary("")
 			if summary == nil {
 				t.Fatalf("Failed to generate summary from plan file %s", tt.planFile)
 			}
@@ -243,7 +243,7 @@ func TestPropertyChangesFormatterTerraformIntegration(t *testing.T) {
 
 	cfg := getTestConfig()
 	analyzer := NewAnalyzer(plan, cfg)
-	summary := analyzer.GenerateSummary("")
+	summary, _ := analyzer.GenerateSummary("")
 	if summary == nil {
 		t.Fatal("Failed to generate summary")
 	}
@@ -307,7 +307,7 @@ func TestEmptyTableSuppressionLogic(t *testing.T) {
 
 	cfg := getTestConfig()
 	analyzer := NewAnalyzer(plan, cfg)
-	summary := analyzer.GenerateSummary("")
+	summary, _ := analyzer.GenerateSummary("")
 	if summary == nil {
 		t.Fatal("Failed to generate summary")
 	}
@@ -357,7 +357,7 @@ func TestRiskBasedSortingBehavior(t *testing.T) {
 	}
 
 	analyzer := NewAnalyzer(plan, cfg)
-	summary := analyzer.GenerateSummary("")
+	summary, _ := analyzer.GenerateSummary("")
 	if summary == nil {
 		t.Fatal("Failed to generate summary")
 	}
@@ -403,7 +403,7 @@ func TestBackwardCompatibility(t *testing.T) {
 			}
 
 			analyzer := NewAnalyzer(plan, cfg)
-			summary := analyzer.GenerateSummary("")
+			summary, _ := analyzer.GenerateSummary("")
 			if summary == nil {
 				t.Fatal("Failed to generate summary")
 			}

--- a/lib/plan/output_refinements_edge_cases_test.go
+++ b/lib/plan/output_refinements_edge_cases_test.go
@@ -32,7 +32,7 @@ func TestOutputRefinements_EdgeCases_EmptyPlan(t *testing.T) {
 	}
 
 	analyzer := NewAnalyzer(plan, cfg)
-	summary := analyzer.GenerateSummary("test_empty_plan.json")
+	summary, _ := analyzer.GenerateSummary("test_empty_plan.json")
 
 	// Verify empty plan handling
 	assert.NotNil(t, summary, "Summary should not be nil for empty plan")
@@ -143,7 +143,7 @@ func TestOutputRefinements_EdgeCases_OnlyNoOps(t *testing.T) {
 			}
 
 			analyzer := NewAnalyzer(plan, cfg)
-			summary := analyzer.GenerateSummary("test_only_noops.json")
+			summary, _ := analyzer.GenerateSummary("test_only_noops.json")
 
 			// Verify all resources are marked as no-op
 			for _, resource := range summary.ResourceChanges {
@@ -281,7 +281,7 @@ func TestOutputRefinements_EdgeCases_ComplexSensitiveStructures(t *testing.T) {
 	}
 
 	analyzer := NewAnalyzer(plan, cfg)
-	summary := analyzer.GenerateSummary("test_complex_sensitive.json")
+	summary, _ := analyzer.GenerateSummary("test_complex_sensitive.json")
 
 	// Find the update resource
 	var updateResource *ResourceChange
@@ -501,7 +501,7 @@ func TestOutputRefinements_EdgeCases_LargePlansPerformance(t *testing.T) {
 
 	// Time the analysis
 	start := time.Now()
-	summary := analyzer.GenerateSummary("test_large_plan.json")
+	summary, _ := analyzer.GenerateSummary("test_large_plan.json")
 	analysisTime := time.Since(start)
 
 	// Time the formatting

--- a/lib/plan/output_refinements_integration_test.go
+++ b/lib/plan/output_refinements_integration_test.go
@@ -110,7 +110,7 @@ func TestOutputRefinements_ComprehensiveWorkflow(t *testing.T) {
 
 			// Test analyzer with output refinements
 			analyzer := NewAnalyzer(plan, cfg)
-			summary := analyzer.GenerateSummary(testDataPath)
+			summary, _ := analyzer.GenerateSummary(testDataPath)
 			require.NotNil(t, summary, "Summary should not be nil")
 
 			// Test formatter filtering by creating formatter and using internal methods
@@ -260,7 +260,7 @@ func TestOutputRefinements_ConfigurationPrecedence(t *testing.T) {
 			}
 
 			analyzer := NewAnalyzer(plan, cfg)
-			summary := analyzer.GenerateSummary(testDataPath)
+			summary, _ := analyzer.GenerateSummary(testDataPath)
 
 			formatter := NewFormatter(cfg)
 			filteredResources := formatter.filterNoOps(summary.ResourceChanges)
@@ -305,7 +305,7 @@ func TestOutputRefinements_BackwardCompatibility(t *testing.T) {
 			}
 
 			analyzer := NewAnalyzer(plan, cfg)
-			summary := analyzer.GenerateSummary(testDataPath)
+			summary, _ := analyzer.GenerateSummary(testDataPath)
 			require.NotNil(t, summary, "Summary should not be nil for existing plan file")
 
 			// Ensure formatter works with existing plans
@@ -360,7 +360,7 @@ func TestOutputRefinements_PropertySortingIntegration(t *testing.T) {
 	}
 
 	analyzer := NewAnalyzer(plan, cfg)
-	summary := analyzer.GenerateSummary(testDataPath)
+	summary, _ := analyzer.GenerateSummary(testDataPath)
 
 	// Find a resource with property changes to verify sorting
 	var updateResource *ResourceChange
@@ -416,7 +416,7 @@ func TestOutputRefinements_SensitiveMaskingIntegration(t *testing.T) {
 	}
 
 	analyzer := NewAnalyzer(plan, cfg)
-	summary := analyzer.GenerateSummary(testDataPath)
+	summary, _ := analyzer.GenerateSummary(testDataPath)
 
 	// Test that sensitive properties are correctly identified in resource changes
 	sensitiveFound := false

--- a/lib/plan/outputs_edge_cases_test.go
+++ b/lib/plan/outputs_edge_cases_test.go
@@ -84,7 +84,7 @@ func TestSensitiveOutputsWithUnknownValues(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := getTestConfig()
 			analyzer := NewAnalyzer(tt.plan, cfg)
-			summary := analyzer.GenerateSummary("")
+			summary, _ := analyzer.GenerateSummary("")
 
 			require.NotNil(t, summary, "Summary should not be nil")
 			require.NotEmpty(t, summary.OutputChanges, "Should have output changes")
@@ -187,7 +187,7 @@ func TestLargeOutputValues(t *testing.T) {
 
 			cfg := getTestConfig()
 			analyzer := NewAnalyzer(plan, cfg)
-			summary := analyzer.GenerateSummary("")
+			summary, _ := analyzer.GenerateSummary("")
 
 			require.NotNil(t, summary, "Summary should not be nil")
 			require.Len(t, summary.OutputChanges, 2, "Should have 2 output changes")
@@ -298,7 +298,7 @@ func TestMalformedOutputStructures(t *testing.T) {
 			analyzer := NewAnalyzer(tt.plan, cfg)
 
 			// This should not panic or crash
-			summary := analyzer.GenerateSummary("")
+			summary, _ := analyzer.GenerateSummary("")
 
 			require.NotNil(t, summary, "Summary should not be nil even with malformed data")
 
@@ -380,7 +380,7 @@ func TestPlansWithOnlyOutputChanges(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := getTestConfig()
 			analyzer := NewAnalyzer(tt.plan, cfg)
-			summary := analyzer.GenerateSummary("")
+			summary, _ := analyzer.GenerateSummary("")
 
 			require.NotNil(t, summary, "Summary should not be nil")
 
@@ -497,7 +497,7 @@ func TestOutputPerformanceWithLargeOutputSets(t *testing.T) {
 
 			cfg := getTestConfig()
 			analyzer := NewAnalyzer(plan, cfg)
-			summary := analyzer.GenerateSummary("")
+			summary, _ := analyzer.GenerateSummary("")
 
 			require.NotNil(t, summary, "Summary should not be nil")
 			// Note: Some outputs might be filtered out due to processing logic

--- a/lib/plan/performance_integration_test.go
+++ b/lib/plan/performance_integration_test.go
@@ -65,7 +65,7 @@ func TestPerformanceLimitsWithLargePlans(t *testing.T) {
 			plan := generateLargeSyntheticPlan(tt.numResources, tt.propertiesPerResource)
 
 			analyzer := NewAnalyzer(plan, cfg)
-			summary := analyzer.GenerateSummary("")
+			summary, _ := analyzer.GenerateSummary("")
 
 			if summary == nil {
 				t.Fatal("Expected summary to be generated even with large plans")
@@ -132,7 +132,7 @@ func TestFormatterPerformanceWithLargePlans(t *testing.T) {
 
 	cfg := getTestConfig()
 	analyzer := NewAnalyzer(plan, cfg)
-	summary := analyzer.GenerateSummary("")
+	summary, _ := analyzer.GenerateSummary("")
 
 	if summary == nil {
 		t.Fatal("Expected summary to be generated")
@@ -175,7 +175,7 @@ func TestProviderGroupingWithLargePlans(t *testing.T) {
 	cfg.Plan.Grouping.Threshold = 10 // Low threshold to trigger grouping
 
 	analyzer := NewAnalyzer(plan, cfg)
-	summary := analyzer.GenerateSummary("")
+	summary, _ := analyzer.GenerateSummary("")
 
 	if summary == nil {
 		t.Fatal("Expected summary to be generated")

--- a/lib/plan/performance_test.go
+++ b/lib/plan/performance_test.go
@@ -20,7 +20,7 @@ func BenchmarkAnalysis_SmallPlan(b *testing.B) {
 	analyzer := NewAnalyzer(nil, cfg)
 
 	for b.Loop() {
-		summary := analyzer.GenerateSummary(planPath)
+		summary, _ := analyzer.GenerateSummary(planPath)
 		if summary == nil {
 			b.Fatal("Expected non-nil summary")
 		}
@@ -36,7 +36,7 @@ func BenchmarkAnalysis_MediumPlan(b *testing.B) {
 	analyzer := NewAnalyzer(nil, cfg)
 
 	for b.Loop() {
-		summary := analyzer.GenerateSummary(planPath)
+		summary, _ := analyzer.GenerateSummary(planPath)
 		if summary == nil {
 			b.Fatal("Expected non-nil summary")
 		}
@@ -52,7 +52,7 @@ func BenchmarkAnalysis_LargePlan(b *testing.B) {
 	analyzer := NewAnalyzer(nil, cfg)
 
 	for b.Loop() {
-		summary := analyzer.GenerateSummary(planPath)
+		summary, _ := analyzer.GenerateSummary(planPath)
 		if summary == nil {
 			b.Fatal("Expected non-nil summary")
 		}
@@ -69,7 +69,7 @@ func BenchmarkFormatting_ProgressiveDisclosure(b *testing.B) {
 	analyzer := NewAnalyzer(nil, cfg)
 	formatter := NewFormatter(cfg)
 
-	summary := analyzer.GenerateSummary(planPath)
+	summary, _ := analyzer.GenerateSummary(planPath)
 	if summary == nil {
 		b.Fatal("Failed to generate summary for benchmark")
 	}
@@ -97,7 +97,7 @@ func BenchmarkFormatting_GroupedSections(b *testing.B) {
 	analyzer := NewAnalyzer(nil, cfg)
 	formatter := NewFormatter(cfg)
 
-	summary := analyzer.GenerateSummary(planPath)
+	summary, _ := analyzer.GenerateSummary(planPath)
 	if summary == nil {
 		b.Fatal("Failed to generate summary for benchmark")
 	}
@@ -138,7 +138,7 @@ func BenchmarkPropertyAnalysis(b *testing.B) {
 
 			b.ResetTimer()
 			for b.Loop() {
-				summary := analyzer.GenerateSummary(planPath)
+				summary, _ := analyzer.GenerateSummary(planPath)
 				if summary == nil {
 					b.Fatal("Expected non-nil summary")
 				}
@@ -188,7 +188,7 @@ func TestPerformanceTargets(t *testing.T) {
 			analyzer := NewAnalyzer(nil, cfg)
 
 			start := time.Now()
-			summary := analyzer.GenerateSummary(planPath)
+			summary, _ := analyzer.GenerateSummary(planPath)
 			duration := time.Since(start)
 
 			if summary == nil {
@@ -222,7 +222,7 @@ func TestMemoryUsage(t *testing.T) {
 	cfg := getBenchmarkConfig()
 	analyzer := NewAnalyzer(nil, cfg)
 
-	summary := analyzer.GenerateSummary(planPath)
+	summary, _ := analyzer.GenerateSummary(planPath)
 	if summary == nil {
 		t.Fatal("Expected non-nil summary")
 	}
@@ -268,7 +268,7 @@ func TestPerformanceLimitsEnforcement(t *testing.T) {
 	analyzer := NewAnalyzer(nil, cfg)
 
 	start := time.Now()
-	summary := analyzer.GenerateSummary(planPath)
+	summary, _ := analyzer.GenerateSummary(planPath)
 	duration := time.Since(start)
 
 	if summary == nil {
@@ -303,7 +303,7 @@ func TestCollapsibleFormatterPerformance(t *testing.T) {
 	analyzer1 := NewAnalyzer(nil, cfg1)
 	formatter1 := NewFormatter(cfg1)
 
-	summary1 := analyzer1.GenerateSummary(planPath)
+	summary1, _ := analyzer1.GenerateSummary(planPath)
 	if summary1 == nil {
 		t.Fatal("Expected non-nil summary for first formatter test")
 	}
@@ -321,7 +321,7 @@ func TestCollapsibleFormatterPerformance(t *testing.T) {
 	analyzer2 := NewAnalyzer(nil, cfg2)
 	formatter2 := NewFormatter(cfg2)
 
-	summary2 := analyzer2.GenerateSummary(planPath)
+	summary2, _ := analyzer2.GenerateSummary(planPath)
 	if summary2 == nil {
 		t.Fatal("Failed to generate summary")
 	}

--- a/lib/plan/unknown_parent_propagation_regression_test.go
+++ b/lib/plan/unknown_parent_propagation_regression_test.go
@@ -147,7 +147,7 @@ func TestUnknownParentPropagationToNestedProperties(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			cfg := getTestConfig()
 			analyzer := NewAnalyzer(tc.plan, cfg)
-			summary := analyzer.GenerateSummary("")
+			summary, _ := analyzer.GenerateSummary("")
 
 			require.NotNil(t, summary, "Summary should not be nil")
 			require.Len(t, summary.ResourceChanges, 1, "Should have exactly one resource change")

--- a/lib/plan/unknown_values_edge_cases_test.go
+++ b/lib/plan/unknown_values_edge_cases_test.go
@@ -129,7 +129,7 @@ func TestComplexNestedUnknownValues(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := getTestConfig()
 			analyzer := NewAnalyzer(tt.plan, cfg)
-			summary := analyzer.GenerateSummary("")
+			summary, _ := analyzer.GenerateSummary("")
 
 			require.NotNil(t, summary, "Summary should not be nil")
 			require.Len(t, summary.ResourceChanges, 1, "Should have exactly one resource change")
@@ -248,7 +248,7 @@ func TestArraysWithUnknownElements(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := getTestConfig()
 			analyzer := NewAnalyzer(tt.plan, cfg)
-			summary := analyzer.GenerateSummary("")
+			summary, _ := analyzer.GenerateSummary("")
 
 			require.NotNil(t, summary, "Summary should not be nil")
 			require.Len(t, summary.ResourceChanges, 1, "Should have exactly one resource change")
@@ -370,7 +370,7 @@ func TestPropertiesRemainingUnknown(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := getTestConfig()
 			analyzer := NewAnalyzer(tt.plan, cfg)
-			summary := analyzer.GenerateSummary("")
+			summary, _ := analyzer.GenerateSummary("")
 
 			require.NotNil(t, summary, "Summary should not be nil")
 			require.Len(t, summary.ResourceChanges, 1, "Should have exactly one resource change")
@@ -450,7 +450,7 @@ func TestLargePlansWithManyUnknownValues(t *testing.T) {
 			plan := generateLargePlanWithUnknownValues(tt.numResources, tt.unknownPropsRate)
 
 			analyzer := NewAnalyzer(plan, cfg)
-			summary := analyzer.GenerateSummary("")
+			summary, _ := analyzer.GenerateSummary("")
 
 			require.NotNil(t, summary, "Summary should be generated even with many unknown values")
 			assert.Len(t, summary.ResourceChanges, tt.numResources, "Should process all resources")


### PR DESCRIPTION
Fixes GenerateSummary dropping LoadPlan errors and returning nil, causing generic 'plan summary cannot be nil' instead of the real error. Changed GenerateSummary to return (*PlanSummary, error) and propagated errors to CLI.

- Changed GenerateSummary signature to return error
- Updated CLI caller to handle and display the real error
- Updated all 57 call sites across 15 test files
- All tests pass, linter clean