### PR TITLE
Fix T-416: Mark output no-ops for identical values

### DIFF
--- a/lib/plan/analyzer.go
+++ b/lib/plan/analyzer.go
@@ -1030,9 +1030,10 @@ func (a *Analyzer) analyzeOutputChange(name string, change *tfjson.Change) (*Out
 		}
 	}
 
-	// Detect no-op outputs from Terraform action metadata only.
-	// Replace/create/update actions can still have equal before/after values.
-	isNoOp := changeType == ChangeTypeNoOp
+	// Detect no-op outputs: explicit no-op action OR update with identical before/after values.
+	// Replace actions with equal values are intentionally excluded (not treated as no-op).
+	isNoOp := changeType == ChangeTypeNoOp ||
+		(changeType == ChangeTypeUpdate && reflect.DeepEqual(change.Before, change.After))
 
 	outputChange := &OutputChange{
 		Name:       name,

--- a/lib/plan/analyzer.go
+++ b/lib/plan/analyzer.go
@@ -1032,8 +1032,10 @@ func (a *Analyzer) analyzeOutputChange(name string, change *tfjson.Change) (*Out
 
 	// Detect no-op outputs: explicit no-op action OR update with identical before/after values.
 	// Replace actions with equal values are intentionally excluded (not treated as no-op).
+	// Unknown outputs are excluded: AfterUnknown with true values means the real value is
+	// unresolved, so equal before/after is coincidental, not a true no-op.
 	isNoOp := changeType == ChangeTypeNoOp ||
-		(changeType == ChangeTypeUpdate && reflect.DeepEqual(change.Before, change.After))
+		(changeType == ChangeTypeUpdate && !isUnknown && reflect.DeepEqual(change.Before, change.After))
 
 	outputChange := &OutputChange{
 		Name:       name,

--- a/lib/plan/analyzer_outputs_test.go
+++ b/lib/plan/analyzer_outputs_test.go
@@ -661,6 +661,29 @@ func TestAnalyzeOutputChangeUpdateWithEqualValuesIsNoOp(t *testing.T) {
 	assert.True(t, result.IsNoOp, "update actions with identical before/after should be treated as no-op")
 }
 
+// TestAnalyzeOutputChangeUnknownUpdateWithEqualValuesIsNotNoOp verifies that an update
+// with equal before/after but AfterUnknown=true is NOT treated as a no-op.
+func TestAnalyzeOutputChangeUnknownUpdateWithEqualValuesIsNotNoOp(t *testing.T) {
+	analyzer := &Analyzer{}
+
+	result, err := analyzer.analyzeOutputChange("pending_output", &tfjson.Change{
+		Actions:      []tfjson.Action{tfjson.ActionUpdate},
+		Before:       "same-value",
+		After:        "same-value",
+		AfterUnknown: true,
+	})
+
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	if result == nil {
+		return
+	}
+
+	assert.Equal(t, ChangeTypeUpdate, result.ChangeType)
+	assert.True(t, result.IsUnknown, "output with AfterUnknown=true should be marked unknown")
+	assert.False(t, result.IsNoOp, "unknown outputs with equal before/after should NOT be treated as no-op")
+}
+
 // TestGetOutputActionAndIndicator tests the output action and indicator mapping function (Task 7.1)
 func TestGetOutputActionAndIndicator(t *testing.T) {
 	analyzer := &Analyzer{}

--- a/lib/plan/analyzer_outputs_test.go
+++ b/lib/plan/analyzer_outputs_test.go
@@ -642,6 +642,25 @@ func TestAnalyzeOutputChangeReplaceWithEqualValuesIsNotNoOp(t *testing.T) {
 	assert.False(t, result.IsNoOp, "replace actions must not be treated as no-op")
 }
 
+func TestAnalyzeOutputChangeUpdateWithEqualValuesIsNoOp(t *testing.T) {
+	analyzer := &Analyzer{}
+
+	result, err := analyzer.analyzeOutputChange("unchanged_output", &tfjson.Change{
+		Actions: []tfjson.Action{tfjson.ActionUpdate},
+		Before:  "same-value",
+		After:   "same-value",
+	})
+
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	if result == nil {
+		return
+	}
+
+	assert.Equal(t, ChangeTypeUpdate, result.ChangeType)
+	assert.True(t, result.IsNoOp, "update actions with identical before/after should be treated as no-op")
+}
+
 // TestGetOutputActionAndIndicator tests the output action and indicator mapping function (Task 7.1)
 func TestGetOutputActionAndIndicator(t *testing.T) {
 	analyzer := &Analyzer{}


### PR DESCRIPTION
Fixes OutputChange.IsNoOp only being set for ChangeTypeNoOp. Now also marks update actions as no-op when Before/After are identical via reflect.DeepEqual. Replace actions with equal values remain non-no-op per existing test.

- Added TestAnalyzeOutputChangeUpdateWithEqualValuesIsNoOp
- All tests pass, linter clean