### PR TITLE
Fix T-445: Fix property size cap calculation

### DIFF
--- a/lib/plan/analyzer.go
+++ b/lib/plan/analyzer.go
@@ -695,9 +695,9 @@ func (a *Analyzer) enforcePropertyLimits(analysis *PropertyChangeAnalysis) {
 	// Calculate total size and enforce memory limits
 	totalSize := 0
 	for i, change := range analysis.Changes {
-		size := min(a.estimateValueSize(change.Before)+a.estimateValueSize(change.After),
-			// Cap individual property size
-			limits.MaxPropertySize)
+		// Cap each value individually to avoid understating memory usage
+		size := min(a.estimateValueSize(change.Before), limits.MaxPropertySize) +
+			min(a.estimateValueSize(change.After), limits.MaxPropertySize)
 		analysis.Changes[i].Size = size
 
 		if int64(totalSize+size) > limits.MaxTotalMemory {

--- a/lib/plan/analyzer_utils_test.go
+++ b/lib/plan/analyzer_utils_test.go
@@ -1080,6 +1080,21 @@ func TestEnforcePropertyLimits(t *testing.T) {
 			expectedTruncated: true,
 			testType:          "custom_config_limit",
 		},
+		{
+			name: "large before and after should cap each value individually",
+			initialChanges: []PropertyChange{
+				{
+					Name:   "prop1",
+					Before: string(make([]byte, MaxPropertyValueSize+100)),
+					After:  string(make([]byte, MaxPropertyValueSize+100)),
+					Action: "update",
+				},
+			},
+			expectedCount:     1,
+			expectedTruncated: false,
+			expectedTotalSize: MaxPropertyValueSize * 2,
+			testType:          "size_cap",
+		},
 	}
 
 	for _, tt := range tests {
@@ -1098,6 +1113,10 @@ func TestEnforcePropertyLimits(t *testing.T) {
 			// Verify all remaining changes have Size set
 			for i, change := range analysis.Changes {
 				assert.GreaterOrEqual(t, change.Size, 0, "Change %d should have non-negative size", i)
+			}
+
+			if tt.testType == "size_cap" {
+				assert.Equal(t, tt.expectedTotalSize, analysis.TotalSize, "Total size should reflect individually capped values")
 			}
 		})
 	}


### PR DESCRIPTION
Fixes enforcePropertyLimits capping combined before+after size with a single MaxPropertyValueSize, understating memory usage. Now caps each value individually before summing.

- Added test verifying size equals MaxPropertyValueSize*2 for oversized pairs
- All tests pass, linter clean