### PR TITLE
Fix T-467: JSON format for complex output values

### DIFF
--- a/lib/plan/formatter.go
+++ b/lib/plan/formatter.go
@@ -2,6 +2,7 @@ package plan
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"slices"
@@ -1360,7 +1361,11 @@ func formatOutputValue(value any, sensitive bool, isUnknown bool) string {
 	case string:
 		return fmt.Sprintf("%q", v)
 	default:
-		return fmt.Sprintf("%v", v)
+		b, err := json.Marshal(v)
+		if err != nil {
+			return fmt.Sprintf("%v", v)
+		}
+		return string(b)
 	}
 }
 

--- a/lib/plan/formatter_output_value_test.go
+++ b/lib/plan/formatter_output_value_test.go
@@ -1,0 +1,34 @@
+package plan
+
+import (
+	"testing"
+)
+
+func TestFormatOutputValue(t *testing.T) {
+	tests := []struct {
+		name      string
+		value     any
+		sensitive bool
+		isUnknown bool
+		want      string
+	}{
+		{"unknown", "anything", false, true, knownAfterApply},
+		{"sensitive", "secret", true, false, "(sensitive value)"},
+		{"nil", nil, false, false, "-"},
+		{"string", "hello", false, false, `"hello"`},
+		{"number", float64(42), false, false, "42"},
+		{"bool", true, false, false, "true"},
+		{"map_stable_order", map[string]any{"b": 2, "a": 1}, false, false, `{"a":1,"b":2}`},
+		{"slice", []any{"x", "y"}, false, false, `["x","y"]`},
+		{"nested_map", map[string]any{"key": map[string]any{"inner": "val"}}, false, false, `{"key":{"inner":"val"}}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatOutputValue(tt.value, tt.sensitive, tt.isUnknown)
+			if got != tt.want {
+				t.Errorf("formatOutputValue() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes formatOutputValue using fmt.Sprintf for maps/slices, producing Go syntax with nondeterministic key order. Now uses json.Marshal for non-string values with fallback to fmt.Sprintf.

- Added comprehensive table-driven tests for all value types
- All tests pass, linter clean