### PR TITLE
Fix T-523: Sensitive-only empty table for no-op changes

### DIFF
--- a/lib/plan/formatter.go
+++ b/lib/plan/formatter.go
@@ -1135,17 +1135,6 @@ func (f *Formatter) shouldAutoExpandProvider(resources []ResourceChange) bool {
 	return false
 }
 
-// filterSensitiveChanges returns only the changes marked as dangerous/sensitive
-func (f *Formatter) filterSensitiveChanges(changes []ResourceChange) []ResourceChange {
-	var sensitive []ResourceChange
-	for _, change := range changes {
-		if change.IsDangerous {
-			sensitive = append(sensitive, change)
-		}
-	}
-	return sensitive
-}
-
 // getCollapsibleTableFormat returns collapsible-enabled table format with specific style
 func (f *Formatter) getCollapsibleTableFormat(style string) output.Format {
 	rendererConfig := f.getRendererConfig()
@@ -1292,12 +1281,11 @@ func (f *Formatter) handleResourceDisplay(summary *PlanSummary, showDetails bool
 
 // handleSensitiveResourceDisplay handles the display of sensitive resources when details are disabled
 func (f *Formatter) handleSensitiveResourceDisplay(summary *PlanSummary, _ *config.OutputConfiguration, builder *output.Builder) error {
-	sensitiveChanges := f.filterSensitiveChanges(summary.ResourceChanges)
-	if len(sensitiveChanges) > 0 {
-		sensitiveData, err := f.createSensitiveResourceChangesDataV2(summary)
-		if err != nil {
-			return fmt.Errorf("failed to create sensitive resource changes data: %w", err)
-		}
+	sensitiveData, err := f.createSensitiveResourceChangesDataV2(summary)
+	if err != nil {
+		return fmt.Errorf("failed to create sensitive resource changes data: %w", err)
+	}
+	if len(sensitiveData) > 0 {
 		sensitiveTable, err := output.NewTableContent("Sensitive Resource Changes", sensitiveData,
 			output.WithKeys("Action", "Resource", "Type", "ID", "Replacement", "Module", "Danger"))
 		if err == nil {

--- a/lib/plan/formatter_edge_cases_test.go
+++ b/lib/plan/formatter_edge_cases_test.go
@@ -1528,3 +1528,39 @@ func TestFormatter_sortResourcesByPriority(t *testing.T) {
 		}
 	})
 }
+
+// TestCreateSensitiveResourceChangesDataV2_NoOpOnlyDangerous verifies that when all
+// dangerous changes are no-ops, createSensitiveResourceChangesDataV2 returns empty data
+// so that handleSensitiveResourceDisplay shows "No sensitive resource changes detected."
+// instead of rendering an empty table. (T-523)
+func TestCreateSensitiveResourceChangesDataV2_NoOpOnlyDangerous(t *testing.T) {
+	cfg := &config.Config{}
+	formatter := NewFormatter(cfg)
+
+	summary := &PlanSummary{
+		ResourceChanges: []ResourceChange{
+			{
+				Address:      "aws_db_instance.main",
+				Type:         "aws_db_instance",
+				ChangeType:   ChangeTypeNoOp,
+				IsDangerous:  true,
+				DangerReason: "Database resource",
+			},
+			{
+				Address:      "aws_rds_instance.replica",
+				Type:         "aws_rds_instance",
+				ChangeType:   ChangeTypeNoOp,
+				IsDangerous:  true,
+				DangerReason: "Database resource",
+			},
+		},
+	}
+
+	data, err := formatter.createSensitiveResourceChangesDataV2(summary)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(data) != 0 {
+		t.Errorf("expected empty data for no-op-only dangerous changes, got %d rows", len(data))
+	}
+}


### PR DESCRIPTION
Checks data length after no-op filtering instead of before, preventing empty sensitive resource table.