### PR TITLE
Fix T-636: Action show-details=false ignored

### DIFF
--- a/action.sh
+++ b/action.sh
@@ -241,7 +241,7 @@ run_analysis() {
   cmd+=("--output" "${INPUT_OUTPUT_FORMAT:-markdown}")
   cmd+=("--file" "$json_file" "--file-format" "json")
 
-  [[ "${INPUT_SHOW_DETAILS:-false}" == "true" ]] && cmd+=("--details")
+  [[ "${INPUT_SHOW_DETAILS:-false}" == "true" ]] && cmd+=("--details=true") || cmd+=("--details=false")
   [[ "${INPUT_EXPAND_ALL:-false}" == "true" ]] && cmd+=("--expand-all")
   [[ -n "${INPUT_CONFIG_FILE:-}" ]] && cmd+=("--config" "$INPUT_CONFIG_FILE")
 

--- a/test/action_test.sh
+++ b/test/action_test.sh
@@ -612,7 +612,7 @@ while [[ $# -gt 0 ]]; do
     --output) shift 2 ;;
     --file) json_file="$2"; shift 2 ;;
     --file-format) shift 2 ;;
-    --details|--expand-all) shift ;;
+    --details|--details=*|--expand-all) shift ;;
     --config) config_file="$2"; shift 2 ;;
     --) saw_separator="true"; shift; plan_file="$1"; shift ;;
     *) echo "unexpected-arg:$1" >&2; exit 99 ;;


### PR DESCRIPTION
Always passes --details=true or --details=false explicitly to override CLI default.