### PR TITLE
Fix T-894: Populate DangerProperties for sensitive changes

### DIFF
--- a/lib/plan/analyzer.go
+++ b/lib/plan/analyzer.go
@@ -964,7 +964,7 @@ func (a *Analyzer) analyzeResourceChanges() []ResourceChange {
 		}
 
 		// Enhanced danger reason logic
-		change.IsDangerous, change.DangerReason = a.evaluateResourceDanger(rc, changeType)
+		change.IsDangerous, change.DangerReason, change.DangerProperties = a.evaluateResourceDanger(rc, changeType)
 
 		changes = append(changes, change)
 	}
@@ -1440,14 +1440,15 @@ func (a *Analyzer) formatReplacePath(path any) string {
 
 // evaluateResourceDanger determines if a resource change is dangerous and provides a descriptive reason.
 // When HighlightDangers is disabled in config, danger detection is suppressed entirely.
-func (a *Analyzer) evaluateResourceDanger(change *tfjson.ResourceChange, changeType ChangeType) (bool, string) {
+func (a *Analyzer) evaluateResourceDanger(change *tfjson.ResourceChange, changeType ChangeType) (bool, string, []string) {
 	// Honor the highlight-dangers flag: when false, suppress all danger detection
 	if a.config != nil && !a.config.Plan.HighlightDangers {
-		return false, ""
+		return false, "", nil
 	}
 
 	isDangerous := false
 	reasonParts := make([]string, 0)
+	var dangerProps []string
 
 	// All deletion operations are considered risky by default
 	if changeType == ChangeTypeDelete {
@@ -1467,7 +1468,7 @@ func (a *Analyzer) evaluateResourceDanger(change *tfjson.ResourceChange, changeT
 
 	// Check for sensitive property changes (only if we have the necessary data)
 	if change.Change != nil {
-		dangerProps := a.checkSensitiveProperties(change)
+		dangerProps = a.checkSensitiveProperties(change)
 		if len(dangerProps) > 0 {
 			isDangerous = true
 			reasonParts = append(reasonParts, a.getSensitivePropertyReason(dangerProps))
@@ -1480,7 +1481,7 @@ func (a *Analyzer) evaluateResourceDanger(change *tfjson.ResourceChange, changeT
 		reason = strings.Join(reasonParts, " and ")
 	}
 
-	return isDangerous, reason
+	return isDangerous, reason, dangerProps
 }
 
 // getSensitiveResourceReason returns a descriptive reason for sensitive resource changes

--- a/lib/plan/analyzer.go
+++ b/lib/plan/analyzer.go
@@ -1481,6 +1481,7 @@ func (a *Analyzer) evaluateResourceDanger(change *tfjson.ResourceChange, changeT
 		reason = strings.Join(reasonParts, " and ")
 	}
 
+	sort.Strings(dangerProps)
 	return isDangerous, reason, dangerProps
 }
 

--- a/lib/plan/analyzer_test.go
+++ b/lib/plan/analyzer_test.go
@@ -828,6 +828,7 @@ func TestEvaluateResourceDanger(t *testing.T) {
 		},
 		SensitiveProperties: []config.SensitiveProperty{
 			{ResourceType: "aws_ec2_instance", Property: "user_data"},
+			{ResourceType: "aws_ec2_instance", Property: "ami"},
 		},
 	}
 	analyzer := &Analyzer{config: cfg}
@@ -944,6 +945,26 @@ func TestEvaluateResourceDanger(t *testing.T) {
 			expectedReason:    "Sensitive resource deletion and User data modification",
 			expectedDangerProps: []string{"user_data"},
 		},
+		{
+			name: "Multiple danger properties should be sorted",
+			change: &tfjson.ResourceChange{
+				Type: "aws_ec2_instance",
+				Change: &tfjson.Change{
+					Before: map[string]any{
+						"user_data": "old-data",
+						"ami":       "ami-old",
+					},
+					After: map[string]any{
+						"user_data": "new-data",
+						"ami":       "ami-new",
+					},
+				},
+			},
+			changeType:          ChangeTypeUpdate,
+			expectedDanger:      true,
+			expectedReason:      "Multiple sensitive properties changed",
+			expectedDangerProps: []string{"ami", "user_data"},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -962,17 +983,11 @@ func TestEvaluateResourceDanger(t *testing.T) {
 			} else {
 				if len(dangerProps) != len(tc.expectedDangerProps) {
 					t.Errorf("evaluateResourceDanger() dangerProps = %v, want %v", dangerProps, tc.expectedDangerProps)
-				}
-				for _, expected := range tc.expectedDangerProps {
-					found := false
-					for _, actual := range dangerProps {
-						if actual == expected {
-							found = true
-							break
+				} else {
+					for i, expected := range tc.expectedDangerProps {
+						if dangerProps[i] != expected {
+							t.Errorf("evaluateResourceDanger() dangerProps[%d] = %q, want %q (full: %v)", i, dangerProps[i], expected, dangerProps)
 						}
-					}
-					if !found {
-						t.Errorf("evaluateResourceDanger() dangerProps missing %q, got %v", expected, dangerProps)
 					}
 				}
 			}

--- a/lib/plan/analyzer_test.go
+++ b/lib/plan/analyzer_test.go
@@ -833,47 +833,52 @@ func TestEvaluateResourceDanger(t *testing.T) {
 	analyzer := &Analyzer{config: cfg}
 
 	testCases := []struct {
-		name           string
-		change         *tfjson.ResourceChange
-		changeType     ChangeType
-		expectedDanger bool
-		expectedReason string
+		name              string
+		change            *tfjson.ResourceChange
+		changeType        ChangeType
+		expectedDanger    bool
+		expectedReason    string
+		expectedDangerProps []string
 	}{
 		{
 			name: "Regular deletion should be dangerous",
 			change: &tfjson.ResourceChange{
 				Type: "aws_s3_bucket",
 			},
-			changeType:     ChangeTypeDelete,
-			expectedDanger: true,
-			expectedReason: "Resource deletion",
+			changeType:        ChangeTypeDelete,
+			expectedDanger:    true,
+			expectedReason:    "Resource deletion",
+			expectedDangerProps: nil,
 		},
 		{
 			name: "Sensitive resource deletion should be dangerous with specific reason",
 			change: &tfjson.ResourceChange{
 				Type: "aws_rds_instance",
 			},
-			changeType:     ChangeTypeDelete,
-			expectedDanger: true,
-			expectedReason: "Sensitive resource deletion",
+			changeType:        ChangeTypeDelete,
+			expectedDanger:    true,
+			expectedReason:    "Sensitive resource deletion",
+			expectedDangerProps: nil,
 		},
 		{
 			name: "Sensitive resource replacement should be dangerous",
 			change: &tfjson.ResourceChange{
 				Type: "aws_rds_instance",
 			},
-			changeType:     ChangeTypeReplace,
-			expectedDanger: true,
-			expectedReason: "Database replacement",
+			changeType:        ChangeTypeReplace,
+			expectedDanger:    true,
+			expectedReason:    "Database replacement",
+			expectedDangerProps: nil,
 		},
 		{
 			name: "EC2 instance replacement should have specific reason",
 			change: &tfjson.ResourceChange{
 				Type: "aws_ec2_instance",
 			},
-			changeType:     ChangeTypeReplace,
-			expectedDanger: true,
-			expectedReason: "Compute instance replacement",
+			changeType:        ChangeTypeReplace,
+			expectedDanger:    true,
+			expectedReason:    "Compute instance replacement",
+			expectedDangerProps: nil,
 		},
 		{
 			name: "Non-sensitive resource update should not be dangerous",
@@ -888,9 +893,10 @@ func TestEvaluateResourceDanger(t *testing.T) {
 					},
 				},
 			},
-			changeType:     ChangeTypeUpdate,
-			expectedDanger: false,
-			expectedReason: "",
+			changeType:        ChangeTypeUpdate,
+			expectedDanger:    false,
+			expectedReason:    "",
+			expectedDangerProps: nil,
 		},
 		{
 			name: "Sensitive property change should be dangerous",
@@ -905,18 +911,20 @@ func TestEvaluateResourceDanger(t *testing.T) {
 					},
 				},
 			},
-			changeType:     ChangeTypeUpdate,
-			expectedDanger: true,
-			expectedReason: "User data modification",
+			changeType:        ChangeTypeUpdate,
+			expectedDanger:    true,
+			expectedReason:    "User data modification",
+			expectedDangerProps: []string{"user_data"},
 		},
 		{
 			name: "Non-sensitive resource creation should not be dangerous",
 			change: &tfjson.ResourceChange{
 				Type: "aws_s3_bucket",
 			},
-			changeType:     ChangeTypeCreate,
-			expectedDanger: false,
-			expectedReason: "",
+			changeType:        ChangeTypeCreate,
+			expectedDanger:    false,
+			expectedReason:    "",
+			expectedDangerProps: nil,
 		},
 		{
 			name: "Multiple danger reasons should be combined",
@@ -931,20 +939,42 @@ func TestEvaluateResourceDanger(t *testing.T) {
 					},
 				},
 			},
-			changeType:     ChangeTypeDelete,
-			expectedDanger: true,
-			expectedReason: "Sensitive resource deletion and User data modification",
+			changeType:        ChangeTypeDelete,
+			expectedDanger:    true,
+			expectedReason:    "Sensitive resource deletion and User data modification",
+			expectedDangerProps: []string{"user_data"},
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			dangerous, reason := analyzer.evaluateResourceDanger(tc.change, tc.changeType)
+			dangerous, reason, dangerProps := analyzer.evaluateResourceDanger(tc.change, tc.changeType)
 			if dangerous != tc.expectedDanger {
 				t.Errorf("evaluateResourceDanger() dangerous = %v, want %v", dangerous, tc.expectedDanger)
 			}
 			if reason != tc.expectedReason {
 				t.Errorf("evaluateResourceDanger() reason = %q, want %q", reason, tc.expectedReason)
+			}
+			if tc.expectedDangerProps == nil {
+				if len(dangerProps) != 0 {
+					t.Errorf("evaluateResourceDanger() dangerProps = %v, want nil/empty", dangerProps)
+				}
+			} else {
+				if len(dangerProps) != len(tc.expectedDangerProps) {
+					t.Errorf("evaluateResourceDanger() dangerProps = %v, want %v", dangerProps, tc.expectedDangerProps)
+				}
+				for _, expected := range tc.expectedDangerProps {
+					found := false
+					for _, actual := range dangerProps {
+						if actual == expected {
+							found = true
+							break
+						}
+					}
+					if !found {
+						t.Errorf("evaluateResourceDanger() dangerProps missing %q, got %v", expected, dangerProps)
+					}
+				}
 			}
 		})
 	}
@@ -962,7 +992,7 @@ func TestEvaluateResourceDangerHighlightDangersDisabled(t *testing.T) {
 	analyzer := &Analyzer{config: cfg}
 
 	// Even a sensitive resource deletion should not be flagged when HighlightDangers is false
-	dangerous, reason := analyzer.evaluateResourceDanger(&tfjson.ResourceChange{
+	dangerous, reason, props := analyzer.evaluateResourceDanger(&tfjson.ResourceChange{
 		Type: "aws_rds_instance",
 	}, ChangeTypeDelete)
 
@@ -971,6 +1001,9 @@ func TestEvaluateResourceDangerHighlightDangersDisabled(t *testing.T) {
 	}
 	if reason != "" {
 		t.Errorf("evaluateResourceDanger() reason should be empty when HighlightDangers is disabled, got %q", reason)
+	}
+	if len(props) != 0 {
+		t.Errorf("evaluateResourceDanger() props should be nil when HighlightDangers is disabled, got %v", props)
 	}
 }
 


### PR DESCRIPTION
Returns dangerProps from evaluateResourceDanger and assigns to ResourceChange.DangerProperties.