### PR TITLE
Fix T-895: Read always-show-sensitive from config

### DIFF
--- a/cmd/plan_summary.go
+++ b/cmd/plan_summary.go
@@ -145,7 +145,9 @@ func runPlanSummary(cmd *cobra.Command, args []string) error {
 	cfg.Plan.ShowStatisticsSummary = viper.GetBool("plan.show-statistics-summary")
 	cfg.Plan.StatisticsSummaryFormat = viper.GetString("plan.statistics-summary-format")
 	cfg.Plan.ShowNoOps = viper.GetBool("plan.show-no-ops")
-	cfg.Plan.AlwaysShowSensitive = viper.GetBool("plan.always-show-sensitive")
+	if viper.IsSet("plan.always-show-sensitive") {
+		cfg.Plan.AlwaysShowSensitive = viper.GetBool("plan.always-show-sensitive")
+	}
 	cfg.ExpandAll = viper.GetBool("expand_all")
 	cfg.UseEmoji = viper.GetBool("use_emoji")
 

--- a/cmd/plan_summary.go
+++ b/cmd/plan_summary.go
@@ -145,6 +145,7 @@ func runPlanSummary(cmd *cobra.Command, args []string) error {
 	cfg.Plan.ShowStatisticsSummary = viper.GetBool("plan.show-statistics-summary")
 	cfg.Plan.StatisticsSummaryFormat = viper.GetString("plan.statistics-summary-format")
 	cfg.Plan.ShowNoOps = viper.GetBool("plan.show-no-ops")
+	cfg.Plan.AlwaysShowSensitive = viper.GetBool("plan.always-show-sensitive")
 	cfg.ExpandAll = viper.GetBool("expand_all")
 	cfg.UseEmoji = viper.GetBool("use_emoji")
 

--- a/cmd/plan_summary_test.go
+++ b/cmd/plan_summary_test.go
@@ -24,6 +24,7 @@ package cmd
 import (
 	"testing"
 
+	"github.com/ArjenSchwarz/strata/config"
 	"github.com/spf13/viper"
 )
 
@@ -260,5 +261,33 @@ func TestPlanSummaryViperConfigRespected(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestAlwaysShowSensitiveDefaultPreserved(t *testing.T) {
+	// Verify that when plan.always-show-sensitive is NOT set in viper,
+	// the default value (true) from GetDefaultConfig is preserved.
+	// This guards against viper.GetBool returning false for unset keys.
+	viper.Reset()
+
+	cfg := config.GetDefaultConfig()
+
+	// Simulate the same logic as runPlanSummary
+	if viper.IsSet("plan.always-show-sensitive") {
+		cfg.Plan.AlwaysShowSensitive = viper.GetBool("plan.always-show-sensitive")
+	}
+
+	if !cfg.Plan.AlwaysShowSensitive {
+		t.Error("AlwaysShowSensitive should default to true when not set in config")
+	}
+
+	// Now verify explicit false overrides the default
+	viper.Set("plan.always-show-sensitive", false)
+	if viper.IsSet("plan.always-show-sensitive") {
+		cfg.Plan.AlwaysShowSensitive = viper.GetBool("plan.always-show-sensitive")
+	}
+
+	if cfg.Plan.AlwaysShowSensitive {
+		t.Error("AlwaysShowSensitive should be false when explicitly set to false in config")
 	}
 }


### PR DESCRIPTION
Adds viper.GetBool read for plan.always-show-sensitive in runPlanSummary.