### PR TITLE
Fix T-949: Validate version command output format

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -86,15 +86,18 @@ var versionCmd = &cobra.Command{
 This command shows the current version of Strata, along with build information
 when available. Use this to verify which version you're running or for
 troubleshooting purposes.`,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if versionOutputFormat != "table" && versionOutputFormat != "json" {
+			return fmt.Errorf("unsupported output format %q: supported formats are table, json", versionOutputFormat)
+		}
+
 		versionInfo := GetVersionInfo()
 
 		switch versionOutputFormat {
 		case "json":
 			jsonData, err := json.MarshalIndent(versionInfo, "", "  ")
 			if err != nil {
-				_, _ = fmt.Fprintf(cmd.OutOrStderr(), "Error marshaling version info to JSON: %v\n", err)
-				return
+				return fmt.Errorf("error marshaling version info to JSON: %w", err)
 			}
 			_, _ = fmt.Fprintln(cmd.OutOrStdout(), string(jsonData))
 		default:
@@ -107,6 +110,8 @@ troubleshooting purposes.`,
 			}
 			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Go: %s\n", versionInfo.GoVersion)
 		}
+
+		return nil
 	},
 }
 

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -86,8 +86,11 @@ func TestVersionCommand(t *testing.T) {
 			versionCmd.SetOut(buf)
 			versionCmd.SetErr(buf)
 
-			// Execute the Run function directly
-			versionCmd.Run(versionCmd, []string{})
+			// Execute the RunE function directly
+			err := versionCmd.RunE(versionCmd, []string{})
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
 
 			// Check output contains expected strings
 			output := buf.String()
@@ -95,6 +98,31 @@ func TestVersionCommand(t *testing.T) {
 				if !bytes.Contains([]byte(output), []byte(expected)) {
 					t.Errorf("Expected output to contain %q, got %q", expected, output)
 				}
+			}
+		})
+	}
+}
+
+func TestVersionCommandUnsupportedFormat(t *testing.T) {
+	originalOutputFormat := versionOutputFormat
+	defer func() {
+		versionOutputFormat = originalOutputFormat
+	}()
+
+	unsupportedFormats := []string{"yaml", "xml", "csv", "html", "markdown"}
+	for _, format := range unsupportedFormats {
+		t.Run(format, func(t *testing.T) {
+			versionOutputFormat = format
+			buf := new(bytes.Buffer)
+			versionCmd.SetOut(buf)
+			versionCmd.SetErr(buf)
+
+			err := versionCmd.RunE(versionCmd, []string{})
+			if err == nil {
+				t.Errorf("Expected error for unsupported format %q, got nil", format)
+			}
+			if !strings.Contains(err.Error(), "unsupported output format") {
+				t.Errorf("Expected error to mention unsupported format, got: %v", err)
 			}
 		})
 	}
@@ -381,8 +409,11 @@ func TestVersionCommandIntegration(t *testing.T) {
 			versionCmd.SetOut(buf)
 			versionCmd.SetErr(buf)
 
-			// Execute the Run function directly
-			versionCmd.Run(versionCmd, []string{})
+			// Execute the RunE function directly
+			err := versionCmd.RunE(versionCmd, []string{})
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
 
 			// Check output
 			output := buf.String()
@@ -438,7 +469,10 @@ func TestVersionCommandConsistency(t *testing.T) {
 			buf := new(bytes.Buffer)
 			versionCmd.SetOut(buf)
 			versionCmd.SetErr(buf)
-			versionCmd.Run(versionCmd, []string{})
+			err := versionCmd.RunE(versionCmd, []string{})
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
 			subcommandOutput := buf.String()
 
 			// Verify version appears in subcommand output
@@ -473,7 +507,10 @@ func TestVersionErrorHandling(t *testing.T) {
 		versionCmd.SetErr(buf)
 
 		// Execute command - should not panic even with edge cases
-		versionCmd.Run(versionCmd, []string{})
+		err := versionCmd.RunE(versionCmd, []string{})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
 
 		output := buf.String()
 		// Should produce valid JSON


### PR DESCRIPTION
Rejects unsupported output formats with error instead of silently falling through to table.