### PR TITLE
Fix T-953: Apply table max column width

### DIFF
--- a/lib/plan/formatter.go
+++ b/lib/plan/formatter.go
@@ -1038,7 +1038,7 @@ func (f *Formatter) getResourceTableSchema() []output.Field {
 		{
 			Name:      "Resource",
 			Type:      "string",
-			Formatter: output.FilePathFormatter(50),
+			Formatter: output.FilePathFormatter(f.config.Table.MaxColumnWidth),
 		},
 		{
 			Name: "Type",


### PR DESCRIPTION
Uses config MaxColumnWidth instead of hardcoded 50 in FilePathFormatter.