### PR TITLE
Fix T-969: Fail early on malformed config files

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -130,7 +130,12 @@ func initConfig() {
 	viper.AutomaticEnv() // read in environment variables that match
 
 	// If a config file is found, read it in.
-	if err := viper.ReadInConfig(); err == nil {
+	if err := viper.ReadInConfig(); err != nil {
+		if cfgFile != "" {
+			// When --config is explicitly provided, surface the error immediately
+			cobra.CheckErr(fmt.Errorf("failed to read config file %s: %w", cfgFile, err))
+		}
+	} else {
 		fmt.Fprintln(os.Stderr, "Using config file:", viper.ConfigFileUsed())
 	}
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,41 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMalformedConfigFile_ReturnsReadError(t *testing.T) {
+	// Create a malformed YAML config file
+	tmpDir := t.TempDir()
+	malformedFile := filepath.Join(tmpDir, "bad.yaml")
+	err := os.WriteFile(malformedFile, []byte(":\ninvalid: [yaml\n"), 0644)
+	require.NoError(t, err)
+
+	// Simulate what initConfig does when --config is explicitly provided
+	v := viper.New()
+	v.SetConfigFile(malformedFile)
+	err = v.ReadInConfig()
+
+	assert.Error(t, err, "ReadInConfig should return an error for malformed YAML")
+	assert.Contains(t, err.Error(), "parsing", "error should mention parsing")
+}
+
+func TestValidConfigFile_NoError(t *testing.T) {
+	tmpDir := t.TempDir()
+	validFile := filepath.Join(tmpDir, "good.yaml")
+	err := os.WriteFile(validFile, []byte("output: json\n"), 0644)
+	require.NoError(t, err)
+
+	v := viper.New()
+	v.SetConfigFile(validFile)
+	err = v.ReadInConfig()
+
+	assert.NoError(t, err, "ReadInConfig should succeed for valid YAML")
+	assert.Equal(t, "json", v.GetString("output"))
+}


### PR DESCRIPTION
Reports config parse errors when --config is explicitly provided instead of masking them.