### PR TITLE
Fix T-1139: Version command rejects empty default output format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Action Argument Safety Regression Tests**: Added unit test coverage for `run_analysis` to validate safe argument handling for plan/config paths containing spaces and for plan files starting with `-`.
 
 ### Fixed
+- **Version Command Default Output Format**: Treat an empty output format as the default (`table`) in the `version` command so it renders table output when invoked without an explicit `--output` flag, instead of returning an "unsupported output format" error.
 - **Property Change Analysis**: Fixed typed nil slice values being classified as "update" instead of "remove" in change analysis, ensuring list property removals are correctly detected regardless of Go nil representation.
 - **Action Command Construction Safety**: Updated `run_analysis` in `action.sh` to build and execute the Strata command as a Bash array (`"${cmd[@]}"`) and pass `--` before the plan file path, preventing argument splitting issues and option ambiguity for user-supplied paths.
 - Corrected output no-op detection so Terraform output `replace` actions are no longer misclassified as no-op when `before` and `after` values are equal.

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -87,13 +87,21 @@ This command shows the current version of Strata, along with build information
 when available. Use this to verify which version you're running or for
 troubleshooting purposes.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if versionOutputFormat != "table" && versionOutputFormat != "json" {
-			return fmt.Errorf("unsupported output format %q: supported formats are table, json", versionOutputFormat)
+		// Treat an empty output format as the default (table). The Cobra flag
+		// default is "table", but the backing variable can be empty when the
+		// command is invoked programmatically without the flag being set.
+		outputFormat := versionOutputFormat
+		if outputFormat == "" {
+			outputFormat = "table"
+		}
+
+		if outputFormat != "table" && outputFormat != "json" {
+			return fmt.Errorf("unsupported output format %q: supported formats are table, json", outputFormat)
 		}
 
 		versionInfo := GetVersionInfo()
 
-		switch versionOutputFormat {
+		switch outputFormat {
 		case "json":
 			jsonData, err := json.MarshalIndent(versionInfo, "", "  ")
 			if err != nil {


### PR DESCRIPTION
## Summary

Fixes T-1139. The `version` command rejected an empty output format with `unsupported output format "": supported formats are table, json`, breaking the `cmd` integration test `TestVersionCommandIntegration/default_output_format`.

## Root Cause

`versionCmd.RunE` in `cmd/version.go` validated `versionOutputFormat` against the literal strings `"table"` and `"json"` before applying any default. The Cobra flag default is `"table"`, but that default is only applied during flag parsing. When `RunE` runs against an empty backing variable (as the integration test does, and as happens for any programmatic invocation without flag parsing), validation sees `""` and rejects it.

## Fix

Normalize an empty `versionOutputFormat` to `"table"` into a local variable before validation, and use that normalized value for both validation and the rendering `switch`. Genuinely unsupported, non-empty formats (e.g. `xml`, `yaml`) still return the existing error, preserved by `TestVersionCommandUnsupportedFormat`.

Change is isolated to `cmd/version.go` (12 insertions, 3 deletions) plus a CHANGELOG entry.

## Verification

- `TestVersionCommandIntegration/default_output_format` now passes (previously failed).
- Full `cmd` package tests pass, with and without `INTEGRATION=1`.
- `make build`, `make fmt`, `make vet` pass.
- `TestVersionCommandUnsupportedFormat` still confirms non-empty unsupported formats error.

Note: a separate pre-existing `lib/plan` integration test failure is tracked under T-1140 and is out of scope for this PR.