### PR TITLE
Fix T-1226: Correct invalid shebang in JSON-only action test

### DIFF
--- a/test/action_test.sh
+++ b/test/action_test.sh
@@ -675,6 +675,39 @@ EOF
     fi
 }
 
+# Regression test for T-1226: test scripts must start with a valid shebang.
+# A corrupted shebang (e.g. "#\!/bin/bash" with an escaped bang) makes the
+# kernel reject direct execution with "exec format error" on Linux, even
+# though "bash <script>" still works and hides the problem.
+test_script_shebangs() {
+    log_test "test scripts have a valid shebang"
+
+    local test_scripts_dir
+    test_scripts_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+    local script
+    local bad_scripts=()
+    for script in "$test_scripts_dir"/*.sh; do
+        [ -f "$script" ] || continue
+        # First two bytes must be the "#!" magic. Reject anything else,
+        # including the escaped-bang corruption "#\".
+        local magic
+        magic=$(head -c 2 "$script")
+        if [ "$magic" != "#!" ]; then
+            bad_scripts+=("$(basename "$script"): '$magic'")
+        fi
+    done
+
+    if [ ${#bad_scripts[@]} -eq 0 ]; then
+        echo -e "${GREEN}[PASS]${NC} all test scripts start with a valid '#!' shebang"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        echo -e "${RED}[FAIL]${NC} test scripts with invalid shebang found:"
+        printf '  %s\n' "${bad_scripts[@]}"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+}
+
 # Run all tests
 echo "Running GitHub Action Unit Tests..."
 echo "=================================="
@@ -690,6 +723,7 @@ test_environment_variables
 test_github_context
 test_dual_output_functions
 test_run_analysis_argument_safety
+test_script_shebangs
 
 # Print test summary
 echo ""

--- a/test/test_json_only.sh
+++ b/test/test_json_only.sh
@@ -1,4 +1,4 @@
-#\!/bin/bash
+#!/bin/bash
 # Extract just the JSON test from integration_test.sh
 export INPUT_PLAN_FILE="samples/web-sample.json"
 export INPUT_OUTPUT_FORMAT="json"


### PR DESCRIPTION
## Summary

Fixes T-1226. `test/test_json_only.sh` started with `#\!/bin/bash` (an escaped bang) instead of `#!/bin/bash`. The first two bytes were `0x23 0x5c` (`#\`) rather than the `0x23 0x21` (`#!`) magic, so the kernel rejected direct execution with `fork/exec ./test/test_json_only.sh: exec format error` on Linux. Running via `bash test/test_json_only.sh` succeeded because Bash treats the malformed line as a comment, which hid the issue.

## Root Cause

The shebang carried a literal backslash before the bang (`#\!`), almost certainly from a heredoc/`echo` context where `!` was escaped to avoid history expansion and the escape was written into the file. `execve` only recognises a script when the first two bytes are exactly `#!`, so on Linux the file was an unrecognised executable format (`ENOEXEC`).

## Fix

- `test/test_json_only.sh`: corrected the shebang to `#!/bin/bash`.
- `test/action_test.sh`: added a `test_script_shebangs` regression test that scans every `test/*.sh` script and fails if any does not begin with the `#!` magic bytes. This catches the original bug and prevents the same class of corruption across all test scripts.

## Verification

- `head -1 test/test_json_only.sh` -> `#!/bin/bash`; `xxd` confirms first two bytes are `0x23 0x21`.
- `./test/test_json_only.sh` runs directly with exit 0 (no exec format error).
- `shellcheck test/test_json_only.sh` clean; `bash -n test/test_json_only.sh` clean.
- `make test-action-unit` passes: 40/40 assertions, 0 failures, including the new `test_script_shebangs` test.