### PR TITLE
Fix T-1229: Capture suite counts in aggregate test runner

### DIFF
--- a/test/run_all_tests.sh
+++ b/test/run_all_tests.sh
@@ -64,10 +64,12 @@ run_test_suite() {
         echo -e "${GREEN}✅ Test Suite PASSED: $suite_name${NC}"
         echo -e "${GREEN}   Duration: ${duration}s${NC}"
         
-        # Extract test statistics from log
-        local suite_tests=$(grep -o "Tests run:" "$log_file" | tail -1 | sed 's/Tests run: *//' || echo "0")
-        local suite_passed=$(grep -o "Tests passed:" "$log_file" | tail -1 | sed 's/Tests passed: *//' | sed 's/\x1b\[[0-9;]*m//g' || echo "0")
-        local suite_failed=$(grep -o "Tests failed:" "$log_file" | tail -1 | sed 's/Tests failed: *//' | sed 's/\x1b\[[0-9;]*m//g' || echo "0")
+        # Extract test statistics from log. Match the whole line (not grep -o,
+        # which would return only the label and drop the numeric value) so the
+        # sed pipeline below can pull the number out.
+        local suite_tests=$(grep "Tests run:" "$log_file" | tail -1 | sed 's/Tests run: *//' || echo "0")
+        local suite_passed=$(grep "Tests passed:" "$log_file" | tail -1 | sed 's/Tests passed: *//' | sed 's/\x1b\[[0-9;]*m//g' || echo "0")
+        local suite_failed=$(grep "Tests failed:" "$log_file" | tail -1 | sed 's/Tests failed: *//' | sed 's/\x1b\[[0-9;]*m//g' || echo "0")
         
         # Clean up ANSI color codes from numbers
         suite_tests=$(echo "$suite_tests" | sed 's/[^0-9]//g')
@@ -105,10 +107,11 @@ run_test_suite() {
         echo -e "${RED}   Error output:${NC}"
         tail -10 "$log_file" | sed 's/^/     /'
         
-        # Try to extract partial statistics even from failed runs
-        local suite_tests=$(grep -o "Tests run:" "$log_file" | tail -1 | sed 's/Tests run: *//' | sed 's/[^0-9]//g' || echo "0")
-        local suite_passed=$(grep -o "Tests passed:" "$log_file" | tail -1 | sed 's/Tests passed: *//' | sed 's/\x1b\[[0-9;]*m//g' | sed 's/[^0-9]//g' || echo "0")
-        local suite_failed=$(grep -o "Tests failed:" "$log_file" | tail -1 | sed 's/Tests failed: *//' | sed 's/\x1b\[[0-9;]*m//g' | sed 's/[^0-9]//g' || echo "0")
+        # Try to extract partial statistics even from failed runs. Match the
+        # whole line (not grep -o) so the numeric value is preserved.
+        local suite_tests=$(grep "Tests run:" "$log_file" | tail -1 | sed 's/Tests run: *//' | sed 's/[^0-9]//g' || echo "0")
+        local suite_passed=$(grep "Tests passed:" "$log_file" | tail -1 | sed 's/Tests passed: *//' | sed 's/\x1b\[[0-9;]*m//g' | sed 's/[^0-9]//g' || echo "0")
+        local suite_failed=$(grep "Tests failed:" "$log_file" | tail -1 | sed 's/Tests failed: *//' | sed 's/\x1b\[[0-9;]*m//g' | sed 's/[^0-9]//g' || echo "0")
         
         suite_tests=${suite_tests:-0}
         suite_passed=${suite_passed:-0}


### PR DESCRIPTION
## Summary

Fixes **T-1229** — the aggregate action test runner (`test/run_all_tests.sh`) dropped per-suite test counts, so the final report could show `Total Tests: 0` even when individual suites emitted non-zero counts.

## Root cause

The extraction used `grep -o "Tests run:"` (and the same for `Tests passed:` / `Tests failed:`). The `-o` flag makes `grep` print **only the matched text** — here just the label, not the number after it. The downstream `sed 's/Tests run: *//'` and `sed 's/[^0-9]//g'` then operated on a string with no digits, producing an empty string, which `${var:-0}` defaulted to `0`. As a result `suite_tests`, `suite_passed`, and `suite_failed` were always 0 and the aggregate totals were meaningless.

This affected both the pass path (lines 68-70) and the failure path (lines 109-111).

## Fix

Dropped the `-o` flag from all six `grep` calls so the full matching line (label + number) is captured. The existing `sed` pipeline already strips the label and ANSI colour codes, so both plain and coloured suite output now parse to the correct numeric value. Minimal change, confined to `test/run_all_tests.sh`.

## Verification

- `bash -n test/run_all_tests.sh` — clean
- `shellcheck test/run_all_tests.sh` — no new findings (19 pre-existing style/SC2155 warnings unchanged; none introduced)
- Ran the fixed extraction logic against sample suite logs:
  - plain log `Tests run: 12 / passed 9 / failed 3` → parsed `12 9 3`
  - ANSI-coloured log `20 / 18 / 2` → parsed `20 18 2`
  - aggregate totals: `32 / 27 / 5` (previously `0 / 0 / 0`)