### PR TITLE
Fix T-1258: Nested Env Vars Are Ignored

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -24,6 +24,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -127,6 +128,12 @@ func initConfig() {
 		viper.SetConfigName("strata")
 	}
 
+	// Map nested config keys to conventional environment variable names.
+	// Without this replacer, AutomaticEnv only matches keys verbatim, so a
+	// nested key like "plan.highlight-dangers" would require the impractical
+	// env var "PLAN.HIGHLIGHT-DANGERS". Translating "." and "-" to "_" lets
+	// the conventional "PLAN_HIGHLIGHT_DANGERS" override it.
+	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_", "-", "_"))
 	viper.AutomaticEnv() // read in environment variables that match
 
 	// If a config file is found, read it in.

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -39,3 +39,67 @@ func TestValidConfigFile_NoError(t *testing.T) {
 	assert.NoError(t, err, "ReadInConfig should succeed for valid YAML")
 	assert.Equal(t, "json", v.GetString("output"))
 }
+
+// TestInitConfig_NestedEnvVarOverride is a regression test for T-1258.
+//
+// Bug: initConfig enabled viper.AutomaticEnv() without an env key replacer, so
+// conventional environment variables for nested keys (those containing "." and
+// "-") were ignored. As a result PLAN_HIGHLIGHT_DANGERS=false did not override
+// plan.highlight-dangers, and only the impractical PLAN.HIGHLIGHT-DANGERS=false
+// form worked.
+//
+// Expected: the underscore form of a nested key overrides the config value.
+// Actual (before fix): the underscore form was ignored.
+func TestInitConfig_NestedEnvVarOverride(t *testing.T) {
+	// Each case sets the env var to "true" while the viper default (with no
+	// config value and no bound flag) is the zero value false. The assertion
+	// therefore only passes when the env var is actually read through the
+	// nested key, which is the behaviour the bug broke.
+	tests := []struct {
+		name     string
+		envKey   string
+		envValue string
+		viperKey string
+		expected bool
+	}{
+		{
+			name:     "PLAN_HIGHLIGHT_DANGERS overrides plan.highlight-dangers",
+			envKey:   "PLAN_HIGHLIGHT_DANGERS",
+			envValue: "true",
+			viperKey: "plan.highlight-dangers",
+			expected: true,
+		},
+		{
+			name:     "PLAN_SHOW_DETAILS overrides plan.show-details",
+			envKey:   "PLAN_SHOW_DETAILS",
+			envValue: "true",
+			viperKey: "plan.show-details",
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			viper.Reset()
+			t.Cleanup(viper.Reset)
+
+			// Use an empty config file so the value can only come from the env var.
+			tmpDir := t.TempDir()
+			emptyFile := filepath.Join(tmpDir, "empty.yaml")
+			require.NoError(t, os.WriteFile(emptyFile, []byte{}, 0644))
+
+			// Point initConfig at the empty config via the package-level cfgFile.
+			origCfgFile := cfgFile
+			cfgFile = emptyFile
+			t.Cleanup(func() { cfgFile = origCfgFile })
+
+			t.Setenv(tt.envKey, tt.envValue)
+
+			// Run the real initialization path used in production.
+			initConfig()
+
+			assert.Equal(t, tt.expected, viper.GetBool(tt.viperKey),
+				"%s=%s should override %s", tt.envKey, tt.envValue, tt.viperKey)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes T-1258. `initConfig` enabled `viper.AutomaticEnv()` without an env key replacer, so conventional environment variables for nested config keys (those containing `.` and `-`) were ignored. As a result `PLAN_HIGHLIGHT_DANGERS=false` did not override `plan.highlight-dangers`; only the impractical `PLAN.HIGHLIGHT-DANGERS=false` form worked.

## Root cause

Viper's `AutomaticEnv()` matches environment variables by uppercasing the requested key verbatim. For a nested key like `plan.highlight-dangers`, Viper looked for `PLAN.HIGHLIGHT-DANGERS` rather than the conventional `PLAN_HIGHLIGHT_DANGERS`. Without an env key replacer, `.` and `-` were never translated to `_`, leaving the usable env var name unreachable.

## Fix

Configure `viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_", "-", "_"))` immediately before `viper.AutomaticEnv()` in `initConfig` (`cmd/root.go`). This is the standard Viper idiom for mapping nested config keys to conventional env var names.

## Regression test

Added `TestInitConfig_NestedEnvVarOverride` in `cmd/root_test.go`, which exercises the real `initConfig()` path. Each case sets an env var to `true` (the unset default is `false`), so the assertion only passes when the env var is genuinely read through the nested key. Confirmed it fails before the fix and passes after.

## Verification

- Regression test passes: `go test ./cmd/ -run TestInitConfig_NestedEnvVarOverride -v`
- Full suite passes: `make test`
- `make build`, `make fmt`, `make vet` pass; `golangci-lint run ./cmd/...` reports 0 issues (pre-existing `goconst` issues in `lib/plan/` are unrelated and predate this change)
- Manual E2E: `PLAN_HIGHLIGHT_DANGERS=false ... plan summary --output json samples/web-sample.json` now reports `"High Risk": 0` / `"Action": "Remove"` (danger suppressed); without the env var the default still reports `"High Risk": 1`.

## Affected files

| File | Change |
|------|--------|
| `cmd/root.go` | Added `strings` import and `viper.SetEnvKeyReplacer` before `AutomaticEnv()` |
| `cmd/root_test.go` | Added `TestInitConfig_NestedEnvVarOverride` regression test |