### PR TITLE
Fix T-1228: Capture benchmark durations instead of redirecting them away

### DIFF
--- a/test/test_benchmark_measure_time.sh
+++ b/test/test_benchmark_measure_time.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+
+# Regression test for T-1228: Performance benchmark tests discard measured durations
+#
+# Bug: In test/test_performance_benchmarks.sh the call sites used:
+#     duration=$(measure_time timeout 60 ./action.sh > "$action_log" 2>&1)
+# The redirection applied to measure_time itself, so the duration that
+# measure_time prints on stdout was redirected into the log file instead of
+# being captured into $duration. The command substitution therefore captured
+# an empty string, making every subsequent arithmetic comparison unreliable.
+#
+# This test exercises the measure_time helper the same way the benchmark
+# callers do and asserts that:
+#   1. duration is captured as a non-empty integer (the bug left it empty)
+#   2. the timed command's stdout/stderr lands in the log file, not the duration
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BENCHMARK_SCRIPT="$SCRIPT_DIR/test_performance_benchmarks.sh"
+
+FAILED=0
+
+fail() {
+    echo "[FAIL] $1"
+    FAILED=1
+}
+
+pass() {
+    echo "[PASS] $1"
+}
+
+# Extract just the measure_time function definition from the benchmark script so
+# we can call it without running the whole suite (which would invoke action.sh
+# and download binaries).
+extract_measure_time() {
+    awk '/^measure_time\(\) \{/{flag=1} flag{print} flag&&/^\}/{exit}' "$BENCHMARK_SCRIPT"
+}
+
+if ! grep -q "^measure_time()" "$BENCHMARK_SCRIPT"; then
+    fail "Could not find measure_time definition in $BENCHMARK_SCRIPT"
+    exit 1
+fi
+
+# Source the extracted function into the current shell.
+eval "$(extract_measure_time)"
+
+# Verify the benchmark script no longer redirects the command substitution that
+# wraps measure_time (the root cause of the bug). The fix routes the timed
+# command's output through measure_time's own log-file argument instead.
+# Inspect only the executable call sites (lines containing a measure_time
+# command substitution), ignoring comments, and flag any that still carry an
+# output redirection on the outer command substitution.
+if grep -nE '=\$\(measure_time ' "$BENCHMARK_SCRIPT" \
+    | grep -vE '^[0-9]+:[[:space:]]*#' \
+    | grep -E '> *"?\$?[A-Za-z_/]' >/dev/null; then
+    fail "Found measure_time call substitution with an output redirection on the outer command (reintroduces T-1228)"
+else
+    pass "No measure_time call substitutions redirect the outer command"
+fi
+
+# A fake command that writes to stdout AND stderr, mimicking ./action.sh output.
+fake_command() {
+    echo "stdout line that belongs in the log"
+    echo "stderr line that belongs in the log" >&2
+    return 0
+}
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+action_log="$TMP_DIR/action.log"
+
+# Call measure_time exactly the way the fixed benchmark callers do: pass the log
+# file path so measure_time redirects the timed command's output, and capture
+# the printed duration via command substitution.
+duration=""
+if duration=$(measure_time "$action_log" fake_command); then
+    : # ran successfully
+else
+    fail "measure_time returned non-zero for a successful command"
+fi
+
+# 1. duration must be a non-empty integer (the bug left it empty).
+if [[ "$duration" =~ ^[0-9]+$ ]]; then
+    pass "Captured duration is a non-empty integer: '$duration'"
+else
+    fail "Captured duration is not a valid integer: '$duration' (bug discards the measured duration)"
+fi
+
+# 2. The command's output must be in the log file, not lost or mixed with the duration.
+if [ -f "$action_log" ] && grep -q "stdout line that belongs in the log" "$action_log" \
+    && grep -q "stderr line that belongs in the log" "$action_log"; then
+    pass "Timed command stdout and stderr were written to the log file"
+else
+    fail "Timed command output did not reach the log file"
+fi
+
+# 3. The log file must NOT contain the duration value (that would mean the
+#    redirection swallowed measure_time's printed duration, as in the bug).
+if grep -qx "$duration" "$action_log"; then
+    fail "Log file contains the duration value, indicating the redirection captured measure_time's output (T-1228 bug)"
+else
+    pass "Duration value is not leaked into the log file"
+fi
+
+echo ""
+if [ "$FAILED" -eq 0 ]; then
+    echo "All measure_time regression checks passed."
+    exit 0
+else
+    echo "measure_time regression checks failed."
+    exit 1
+fi

--- a/test/test_performance_benchmarks.sh
+++ b/test/test_performance_benchmarks.sh
@@ -67,19 +67,31 @@ log_perf() {
     fi
 }
 
-# Measure execution time for a command
+# Measure execution time for a command.
+#
+# Usage: duration=$(measure_time <log_file> command [args...])
+#
+# The first argument is the log file that receives the timed command's
+# stdout and stderr. Redirecting inside measure_time (instead of on the
+# command substitution) keeps the printed duration on measure_time's own
+# stdout so the caller can capture it. Wrapping the call site redirection
+# around measure_time would send the duration into the log instead, leaving
+# the caller with an empty value (see T-1228).
 measure_time() {
+    local log_file="$1"
+    shift
+
     local start_time end_time duration
     start_time=$(date +%s)
 
-    # Execute the command passed as arguments
-    "$@"
+    # Execute the command passed as arguments, routing its output to the log.
+    "$@" > "$log_file" 2>&1
     local exit_code=$?
 
     end_time=$(date +%s)
     duration=$((end_time - start_time))
 
-    echo $duration
+    echo "$duration"
     return $exit_code
 }
 
@@ -153,12 +165,12 @@ test_binary_download_performance() {
 
     # Measure total execution time (which includes download)
     local duration
-    if duration=$(measure_time timeout 60 ./action.sh > "$action_log" 2>&1); then
-        log_perf $duration "Binary download + execution" $BINARY_DOWNLOAD_THRESHOLD
+    if duration=$(measure_time "$action_log" timeout 60 ./action.sh); then
+        log_perf "$duration" "Binary download + execution" "$BINARY_DOWNLOAD_THRESHOLD"
 
         # Since we can't easily separate download time from execution time in the current implementation,
         # we measure the total time and ensure it's reasonable for a fresh download
-        if [ $duration -le $BINARY_DOWNLOAD_THRESHOLD ]; then
+        if [ "$duration" -le "$BINARY_DOWNLOAD_THRESHOLD" ]; then
             log_pass "Binary download performance - Within acceptable time"
         else
             # Check if the action actually succeeded
@@ -213,8 +225,8 @@ test_analysis_startup_performance() {
     export GITHUB_OUTPUT="$github_output"
 
     local duration
-    if duration=$(measure_time timeout 30 ./action.sh > "$action_log" 2>&1); then
-        log_perf $duration "Analysis startup (cached)" $ANALYSIS_STARTUP_THRESHOLD
+    if duration=$(measure_time "$action_log" timeout 30 ./action.sh); then
+        log_perf "$duration" "Analysis startup (cached)" "$ANALYSIS_STARTUP_THRESHOLD"
 
         # Verify execution was successful
         if [ -f "$github_output" ] && grep -q "summary=" "$github_output"; then
@@ -258,10 +270,10 @@ test_total_execution_performance() {
         export GITHUB_OUTPUT="$github_output"
 
         local duration
-        if duration=$(measure_time timeout 60 ./action.sh > "$action_log" 2>&1); then
-            log_perf $duration "Total execution ($sample_name)" $TOTAL_EXECUTION_THRESHOLD
+        if duration=$(measure_time "$action_log" timeout 60 ./action.sh); then
+            log_perf "$duration" "Total execution ($sample_name)" "$TOTAL_EXECUTION_THRESHOLD"
 
-            if [ $duration -le $TOTAL_EXECUTION_THRESHOLD ]; then
+            if [ "$duration" -le "$TOTAL_EXECUTION_THRESHOLD" ]; then
                 passed_count=$((passed_count + 1))
             fi
 
@@ -316,9 +328,9 @@ test_performance_baseline_comparison() {
         export GITHUB_OUTPUT="$github_output"
 
         local duration
-        if duration=$(measure_time ./action.sh > "$action_log" 2>&1); then
-            durations+=($duration)
-            log_perf $duration "Baseline iteration $iteration"
+        if duration=$(measure_time "$action_log" ./action.sh); then
+            durations+=("$duration")
+            log_perf "$duration" "Baseline iteration $iteration"
         else
             log_fail "Performance baseline - Iteration $iteration failed"
             unset INPUT_PLAN_FILE INPUT_OUTPUT_FORMAT INPUT_COMMENT_ON_PR GITHUB_STEP_SUMMARY GITHUB_OUTPUT


### PR DESCRIPTION
## Summary

`test/test_performance_benchmarks.sh` measured durations with command substitutions like:

```sh
duration=$(measure_time timeout 60 ./action.sh > "$action_log" 2>&1)
```

The `> "$action_log" 2>&1` redirection bound to the whole `measure_time` invocation rather than the inner `./action.sh`. Because `measure_time` returns its result by printing the duration to stdout, that value was redirected into the log file and the command substitution captured an empty string. Every subsequent integer comparison (`[ "$duration" -le ... ]`) then ran against an empty value, making the benchmark assertions unreliable. ShellCheck 0.9+ flags this as SC2327 (warning) and SC2328 (error).

## Root cause

Redirection scoping error: in `cmd args > file` the redirection applies to the entire simple command (`measure_time ...`), not to the argument that happens to be a command name.

## Fix

- `measure_time` now takes the log-file path as its first argument and redirects only the timed command's output (`"$@" > "$log_file" 2>&1`), keeping its own stdout clean for capture.
- All four call sites updated to pass the log file as the first argument and drop the outer redirection.
- Touched variable references quoted.

`measure_time` is defined and used only in this file, so the signature change is safe and touches no shared helper.

## Verification

- New regression test `test/test_benchmark_measure_time.sh` confirms the duration is captured as a non-empty integer, the timed command's output reaches the log, the duration is not leaked into the log, and no call site redirects the outer command.
- ShellCheck 0.11.0: original file reports SC2327 x4 + SC2328 x4; fixed file reports neither.
- `bash -n` passes on both files; `go build ./...` succeeds.

Bugfix details tracked under T-1228.