### PR TITLE
Fix T-1140: Enable danger detection in integration test configs

### DIFF
--- a/lib/plan/integration_test.go
+++ b/lib/plan/integration_test.go
@@ -356,32 +356,19 @@ func getMapKeys(m map[string][]ResourceChange) []string {
 	return keys
 }
 
-// Helper function to create test configuration
+// Helper function to create test configuration.
+// Start from the production defaults (which enable HighlightDangers) and only
+// override the fields the integration tests care about. Hand-constructing a
+// config left HighlightDangers at Go's zero value (false), which silently
+// disabled danger detection in evaluateResourceDanger.
 func getTestConfig() *config.Config {
-	return &config.Config{
-		ExpandAll: false,
-		Plan: config.PlanConfig{
-			ExpandableSections: config.ExpandableSectionsConfig{
-				Enabled:             true,
-				AutoExpandDangerous: true,
-			},
-			Grouping: config.GroupingConfig{
-				Enabled:   true,
-				Threshold: 10,
-			},
-			PerformanceLimits: config.PerformanceLimitsConfig{
-				MaxPropertiesPerResource: 100,
-				MaxPropertySize:          1024 * 1024,       // 1MB
-				MaxTotalMemory:           100 * 1024 * 1024, // 100MB
-				MaxDependencyDepth:       10,
-			},
-		},
-		SensitiveResources: []config.SensitiveResource{
-			{ResourceType: "aws_db_instance"},
-			{ResourceType: "aws_rds_db_instance"},
-		},
-		SensitiveProperties: []config.SensitiveProperty{
-			{ResourceType: "aws_instance", Property: "user_data"},
-		},
+	cfg := config.GetDefaultConfig()
+	cfg.SensitiveResources = []config.SensitiveResource{
+		{ResourceType: "aws_db_instance"},
+		{ResourceType: "aws_rds_db_instance"},
 	}
+	cfg.SensitiveProperties = []config.SensitiveProperty{
+		{ResourceType: "aws_instance", Property: "user_data"},
+	}
+	return cfg
 }

--- a/lib/plan/output_refinements_integration_test.go
+++ b/lib/plan/output_refinements_integration_test.go
@@ -102,6 +102,10 @@ func TestOutputRefinements_ComprehensiveWorkflow(t *testing.T) {
 				Plan: config.PlanConfig{
 					ShowDetails: true,
 					ShowContext: true,
+					// Danger detection is suppressed when HighlightDangers is
+					// false; enable it so sensitive/destructive resources get
+					// flagged for the dangerous-count assertions below.
+					HighlightDangers: true,
 				},
 			}
 			if tc.configOverride != nil {


### PR DESCRIPTION
## Summary

`make test-integration` failed in `lib/plan` because integration tests expected sensitive/destructive resources to be flagged as dangerous, but none were.

## Root cause

The integration tests hand-constructed `config.Config` values without setting `Plan.HighlightDangers`, leaving it at Go's zero value (`false`). `Analyzer.evaluateResourceDanger` returns early when `HighlightDangers` is false, so destructive/sensitive resources were never flagged.

## Fix

- `getTestConfig()` (in `lib/plan/integration_test.go`) now derives from `config.GetDefaultConfig()` and overrides only `SensitiveResources`/`SensitiveProperties`, inheriting `HighlightDangers: true` and other production defaults.
- `TestOutputRefinements_ComprehensiveWorkflow`'s inline config (in `lib/plan/output_refinements_integration_test.go`) now sets `HighlightDangers: true`.

This fixes the four cases the ticket called out:
- `TestRiskAssessment_Integration`
- `TestPlanSummaryOutputImprovements_EndToEnd/Danger sample - Test all improvements`
- `TestOutputRefinements_ComprehensiveWorkflow/Default behavior ...`
- `TestOutputRefinements_ComprehensiveWorkflow/Show no-ops enabled ...`

## Scope note

The pre-existing staticcheck SA4010 finding in `output_improvements_integration_test.go` (`TestRiskBasedSortingBehavior`) is tracked separately under T-1285 and was deliberately left untouched.

## Validation

- `INTEGRATION=1 go test ./...` — green
- `make test`, `make vet`, `make build` — green

Fixes T-1140.