### PR TITLE
Fix T-1182: Register documented plan summary flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ File paths support placeholders for dynamic naming:
 Examples:
   strata plan summary terraform.tfplan
   strata plan summary --output json terraform.tfplan
-  strata plan summary --show-details terraform.tfplan
+  strata plan summary --details terraform.tfplan
   strata plan summary --expand-all terraform.tfplan
   strata plan summary --file output.json --file-format json terraform.tfplan
   strata plan summary --file "report-$TIMESTAMP-$AWS_REGION.md" --file-format markdown terraform.tfplan
@@ -91,12 +91,14 @@ Usage:
   strata plan summary [flags] PLAN_FILE
 
 Flags:
-  -e, --expand-all             Expand all collapsible sections
-  -h, --help                   help for summary
-      --highlight-dangers      Highlight potentially dangerous changes (default true)
-      --show-details           Show detailed resource changes (default true)
-      --show-statistics        Show statistics summary table (default true)
-      --stats-format string    Statistics summary format (horizontal, vertical) (default "horizontal")
+      --always-show-sensitive   Show sensitive resource changes even when details are disabled (default true)
+      --details                 Show detailed change information (default true)
+  -e, --expand-all              Expand all collapsible sections
+  -h, --help                    help for summary
+      --highlight-dangers       Highlight potentially destructive changes (default true)
+      --show-no-ops             Show no-op resources in the summary
+      --show-statistics         Show statistics summary table (default true)
+      --stats-format string     Statistics summary format (horizontal, vertical) (default "horizontal")
 
 Global Flags:
       --config string          config file (default is ./strata.yaml or ~/.strata.yaml)

--- a/cmd/plan_summary.go
+++ b/cmd/plan_summary.go
@@ -119,6 +119,7 @@ var (
 	showStatisticsSummary   bool
 	statisticsSummaryFormat string
 	showNoOps               bool
+	alwaysShowSensitive     bool
 )
 
 func runPlanSummary(cmd *cobra.Command, args []string) error {
@@ -253,6 +254,14 @@ func init() {
 	planSummaryCmd.Flags().BoolVar(&showNoOps, "show-no-ops", false,
 		"Show no-op resources in the summary")
 	if err := viper.BindPFlag("plan.show-no-ops", planSummaryCmd.Flags().Lookup("show-no-ops")); err != nil {
+		panic(err)
+	}
+
+	// Always show sensitive flag. The default matches GetDefaultConfig so that
+	// omitting the flag preserves the configured/default behaviour.
+	planSummaryCmd.Flags().BoolVar(&alwaysShowSensitive, "always-show-sensitive", true,
+		"Show sensitive resource changes even when details are disabled")
+	if err := viper.BindPFlag("plan.always-show-sensitive", planSummaryCmd.Flags().Lookup("always-show-sensitive")); err != nil {
 		panic(err)
 	}
 }

--- a/cmd/plan_summary_test.go
+++ b/cmd/plan_summary_test.go
@@ -264,6 +264,78 @@ func TestPlanSummaryViperConfigRespected(t *testing.T) {
 	}
 }
 
+func TestAlwaysShowSensitiveFlagRegistered(t *testing.T) {
+	// Regression test for T-1182: docs/implementation/always-show-sensitive.md
+	// documents `--always-show-sensitive=true`, but the flag was never registered.
+	flag := planSummaryCmd.Flags().Lookup("always-show-sensitive")
+	if flag == nil {
+		t.Fatal("always-show-sensitive flag not found")
+	}
+
+	// Default must match GetDefaultConfig (true) so the flag does not change
+	// behaviour when omitted.
+	if flag.DefValue != "true" {
+		t.Errorf("Expected default value to be 'true', got %q", flag.DefValue)
+	}
+
+	expectedUsage := "Show sensitive resource changes even when details are disabled"
+	if flag.Usage != expectedUsage {
+		t.Errorf("Expected usage %q, got %q", expectedUsage, flag.Usage)
+	}
+}
+
+func TestDocumentedFlagsParse(t *testing.T) {
+	// Regression test for T-1182: the exact CLI invocations from the docs must
+	// parse without an "unknown flag" error.
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "details flag (README CLI example)",
+			args: []string{"--details", "terraform.tfplan"},
+		},
+		{
+			name: "always-show-sensitive flag (always-show-sensitive.md example)",
+			args: []string{"--details=false", "--always-show-sensitive=true", "terraform.tfplan"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := planSummaryCmd.ParseFlags(tt.args); err != nil {
+				t.Errorf("ParseFlags(%v) returned error: %v", tt.args, err)
+			}
+		})
+	}
+}
+
+func TestAlwaysShowSensitiveFlagBinding(t *testing.T) {
+	// Regression test for T-1182: when the --always-show-sensitive flag is set
+	// explicitly, the bound viper key must reflect it so runPlanSummary picks it up.
+	defer func() {
+		viper.Reset()
+		// Restore default flag state for other tests.
+		_ = planSummaryCmd.Flags().Set("always-show-sensitive", "true")
+	}()
+
+	viper.Reset()
+	if err := viper.BindPFlag("plan.always-show-sensitive", planSummaryCmd.Flags().Lookup("always-show-sensitive")); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := planSummaryCmd.ParseFlags([]string{"--always-show-sensitive=false"}); err != nil {
+		t.Fatalf("Failed to parse flags: %v", err)
+	}
+
+	if !viper.IsSet("plan.always-show-sensitive") {
+		t.Fatal("expected plan.always-show-sensitive to be set after explicit flag")
+	}
+	if viper.GetBool("plan.always-show-sensitive") {
+		t.Error("expected plan.always-show-sensitive to be false after --always-show-sensitive=false")
+	}
+}
+
 func TestAlwaysShowSensitiveDefaultPreserved(t *testing.T) {
 	// Verify that when plan.always-show-sensitive is NOT set in viper,
 	// the default value (true) from GetDefaultConfig is preserved.

--- a/docs/implementation/always-show-sensitive.md
+++ b/docs/implementation/always-show-sensitive.md
@@ -23,7 +23,8 @@ plan:
   always-show-sensitive: true  # Always show sensitive resources even when details are disabled
 ```
 
-You can also enable it via command-line flags (if implemented):
+You can also control it via command-line flags. The `--always-show-sensitive`
+flag (default `true`) overrides the configuration file value:
 
 ```bash
 strata plan summary --details=false --always-show-sensitive=true terraform.tfplan


### PR DESCRIPTION
## Summary

Fixes T-1182. The documentation described `strata plan summary` CLI flags that the Cobra command did not register, so the documented invocations failed with `unknown flag`.

Two independent doc/code mismatches:
1. README documented the CLI flag as `--show-details`, but the registered flag is `--details` (the GitHub Action input `show-details` internally calls `--details`).
2. `--always-show-sensitive` was never registered as a flag, even though `plan.always-show-sensitive` is a supported config key consumed by `runPlanSummary`.

## Changes

- **`cmd/plan_summary.go`**: Register a `--always-show-sensitive` bool flag (default `true`, matching `GetDefaultConfig`) bound to the existing `plan.always-show-sensitive` viper key. No new behaviour — just a CLI entry point to existing config.
- **`README.md`**: Correct the CLI example and documented Flags block to use `--details` instead of `--show-details`; add the `--always-show-sensitive` and `--show-no-ops` flags. GitHub Action input references (`show-details`) and config-key references were already correct and left unchanged.
- **`docs/implementation/always-show-sensitive.md`**: Remove the "(if implemented)" qualifier; document the now-registered flag.
- **`cmd/plan_summary_test.go`**: Regression tests for flag registration, parsing the documented invocations, and the viper binding.

## Verification

Both exact ticket commands now succeed:
- `strata plan summary samples/simpleadd-sample.json --details`
- `strata plan summary samples/simpleadd-sample.json --details=false --always-show-sensitive=true`

On `samples/danger-sample.json`, `--always-show-sensitive=true` shows the sensitive resource table while `=false` hides it, confirming the flag is functionally wired.

`make build`, `make fmt`, `make vet`, `make test` all pass. `golangci-lint run ./cmd/...` reports 0 issues. (`make lint` reports pre-existing failures from a sibling worktree `../T-1287/`, unrelated to this change.)