### PR TITLE
Fix T-1096: Validate latest cached binary against resolved tag

### DIFF
--- a/action.sh
+++ b/action.sh
@@ -105,9 +105,27 @@ download_strata() {
     local cached_version
     cached_version="$("$STRATA_BIN" --version 2>/dev/null || echo "")"
     if [[ "$version" == "latest" ]]; then
-      echo "✅ Using cached Strata binary"
-      echo "🔍 Strata version: ${cached_version:-unknown}"
-      return 0
+      # The cache key in action.yml uses loose restore-keys, so a "latest" run
+      # can be hydrated from an older pinned-version cache. Resolve the current
+      # latest release tag and only reuse the cached binary when it matches,
+      # otherwise re-download to avoid running a stale binary.
+      local latest_tag
+      if latest_tag=$(get_version_tag "latest"); then
+        if [[ -n "$cached_version" ]] && echo "$cached_version" | grep -qF "${latest_tag#v}"; then
+          echo "✅ Using cached Strata binary (matches latest release $latest_tag)"
+          echo "🔍 Strata version: $cached_version"
+          return 0
+        else
+          echo "⚠️ Cached binary (${cached_version:-unknown}) does not match latest release $latest_tag, re-downloading"
+          rm -f "$STRATA_BIN"
+        fi
+      else
+        # Could not resolve the latest tag (offline / API failure). Fall back to
+        # reusing the cached binary as a best effort rather than failing.
+        echo "⚠️ Could not resolve latest release tag, using cached Strata binary"
+        echo "🔍 Strata version: ${cached_version:-unknown}"
+        return 0
+      fi
     elif [[ -n "$cached_version" ]] && echo "$cached_version" | grep -qF "${version#v}"; then
       echo "✅ Using cached Strata binary (matches requested $version)"
       echo "🔍 Strata version: $cached_version"

--- a/action.yml
+++ b/action.yml
@@ -74,9 +74,11 @@ runs:
       with:
         path: ~/.cache/strata
         key: strata-binary-${{ runner.os }}-${{ runner.arch }}-${{ inputs.strata-version }}
+        # Scope restore-keys to the exact version segment so a "latest" run does
+        # not restore an unrelated pinned-version cache (and vice versa). action.sh
+        # still validates a restored "latest" binary against the current release.
         restore-keys: |
-          strata-binary-${{ runner.os }}-${{ runner.arch }}-
-          strata-binary-${{ runner.os }}-
+          strata-binary-${{ runner.os }}-${{ runner.arch }}-${{ inputs.strata-version }}
     
     - name: Run Strata Analysis
       id: strata-analysis

--- a/test/action_test.sh
+++ b/test/action_test.sh
@@ -675,6 +675,111 @@ EOF
     fi
 }
 
+# Regression test for T-1096: a "latest" run must not reuse a stale cached
+# binary. download_strata must resolve the current latest release tag and only
+# reuse the cached binary when its --version matches that tag. If the cached
+# version is older, the binary must be re-downloaded rather than silently used.
+test_latest_cache_version_validation() {
+    log_test "latest cache validation (T-1096)"
+
+    local run_dir="$TEST_DIR/latest_cache_validation"
+    local harness="$run_dir/latest_cache_harness.sh"
+    mkdir -p "$run_dir"
+
+    # The harness sources download_strata + get_version_tag from action.sh,
+    # then overrides get_version_tag, detect_platform and curl so the network is
+    # never touched. CACHED_VERSION and LATEST_TAG are supplied per scenario.
+    cat > "$harness" <<'EOF'
+#!/bin/bash
+set -uo pipefail
+
+ACTION_PATH="$1"
+CACHE_DIR="$2"
+CACHED_VERSION="$3"
+LATEST_TAG="$4"
+
+mkdir -p "$CACHE_DIR"
+STRATA_BIN="$CACHE_DIR/strata"
+
+# Mock cached binary reporting CACHED_VERSION.
+cat > "$STRATA_BIN" <<MOCK
+#!/bin/bash
+echo "strata version $CACHED_VERSION"
+MOCK
+chmod +x "$STRATA_BIN"
+
+INPUT_STRATA_VERSION="latest"
+GITHUB_API_URL="https://example.invalid"
+
+# Override platform detection to avoid depending on the host.
+detect_platform() { OS="linux"; ARCH="amd64"; }
+
+# Override version resolution to return the controlled latest tag.
+get_version_tag() {
+  if [[ -n "$LATEST_TAG" ]]; then
+    echo "$LATEST_TAG"
+    return 0
+  fi
+  return 1
+}
+
+# Stub curl so any re-download attempt fails fast (no network).
+curl() { return 1; }
+
+# Stub sleep so retry loops do not slow the test down.
+sleep() { :; }
+
+export OS ARCH STRATA_BIN CACHE_DIR INPUT_STRATA_VERSION GITHUB_API_URL
+
+eval "$(sed -n '/^download_strata()/,/^}/p' "$ACTION_PATH")"
+
+download_strata
+EOF
+    chmod +x "$harness"
+
+    # Scenario 1: cached binary is stale relative to the resolved latest tag.
+    # The function must NOT reuse it. With curl stubbed to fail, a re-download
+    # attempt means the function exits non-zero rather than returning 0 with
+    # "Using cached Strata binary".
+    local stale_cache="$run_dir/stale"
+    local stale_output
+    # download_strata exits non-zero once the (stubbed) re-download fails; that
+    # non-zero exit is itself proof the stale cache was rejected. Guard the
+    # assignment so the surrounding `set -e` does not abort the test run.
+    stale_output=$(bash "$harness" "action.sh" "$stale_cache" "v0.0.1" "v1.5.0" 2>&1) || true
+    if echo "$stale_output" | grep -q "Using cached Strata binary"; then
+        echo -e "${RED}[FAIL]${NC} latest run must not reuse a stale cached binary"
+        echo "  Output: $stale_output"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    else
+        echo -e "${GREEN}[PASS]${NC} latest run must not reuse a stale cached binary"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    fi
+
+    # Scenario 2: cached binary matches the resolved latest tag. The function
+    # must reuse it without attempting a download.
+    local match_cache="$run_dir/match"
+    if bash "$harness" "action.sh" "$match_cache" "v1.5.0" "v1.5.0" 2>&1 | grep -q "Using cached Strata binary"; then
+        echo -e "${GREEN}[PASS]${NC} latest run reuses cached binary matching the latest tag"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        echo -e "${RED}[FAIL]${NC} latest run reuses cached binary matching the latest tag"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+
+    # Scenario 3: latest tag cannot be resolved (offline / API failure). The
+    # function should fall back to reusing the cached binary as a best effort
+    # rather than failing the whole action.
+    local offline_cache="$run_dir/offline"
+    if bash "$harness" "action.sh" "$offline_cache" "v0.0.1" "" 2>&1 | grep -qi "cached Strata binary"; then
+        echo -e "${GREEN}[PASS]${NC} latest run reuses cached binary when latest tag cannot be resolved"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        echo -e "${RED}[FAIL]${NC} latest run reuses cached binary when latest tag cannot be resolved"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+}
+
 # Regression test for T-1226: test scripts must start with a valid shebang.
 # A corrupted shebang (e.g. "#\!/bin/bash" with an escaped bang) makes the
 # kernel reject direct execution with "exec format error" on Linux, even
@@ -723,6 +828,7 @@ test_environment_variables
 test_github_context
 test_dual_output_functions
 test_run_analysis_argument_safety
+test_latest_cache_version_validation
 test_script_shebangs
 
 # Print test summary


### PR DESCRIPTION
## Summary

Fixes **T-1096**: the GitHub Action could reuse a stale cached binary when `strata-version: latest`.

`action.sh`'s `download_strata` accepted any executable cached binary at `~/.cache/strata/strata` for `INPUT_STRATA_VERSION=latest` and returned immediately, without resolving the current latest release tag or comparing the cached `--version`. Combined with `action.yml`'s broad cache `restore-keys` (`strata-binary-${os}-${arch}-` and `strata-binary-${os}-`), a `latest` run could restore an older pinned-version cache and skip downloading a newer release. This supersedes the T-1073 behaviour that deliberately reused any cached binary for `latest`.

## Root cause

The `latest` branch of the cache check trusted the cache key to guarantee freshness, but the cache key is not authoritative because `action.yml` `restore-keys` match across versions. No resolution of the actual latest tag was performed at reuse time.

## Fix

- **`action.sh`**: for `latest`, resolve the current latest release tag via the existing `get_version_tag latest` and only reuse the cached binary when its `--version` matches that tag; otherwise delete and re-download. If the tag cannot be resolved (offline / API failure), fall back to reusing the cached binary as best effort rather than failing the action.
- **`action.yml`**: scope `restore-keys` to the exact version segment so a `latest` run no longer restores an unrelated pinned-version cache (and vice versa).
- **`test/action_test.sh`**: add `test_latest_cache_version_validation` covering stale-cache rejection, matching-tag reuse, and offline fallback.

## Validation

- `make test-action-unit` — all 43 unit assertions pass (including the new regression test).
- `make test-action-integration` — binary caching test passes. The 4 "Missing required outputs" failures are pre-existing on `main` (the test greps for `summary=` while the action emits the heredoc `summary<<delim` form) and are unrelated to this change.
- `bash -n action.sh` — syntax OK.
- `shellcheck action.sh` — no new warnings introduced (9 pre-existing warnings unchanged).