### PR TITLE
Fix T-1118: GitHub Action Outputs Zero Changes From JSON File

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **Action Argument Safety Regression Tests**: Added unit test coverage for `run_analysis` to validate safe argument handling for plan/config paths containing spaces and for plan files starting with `-`.
+- **Action Output Extraction Regression Tests**: Added unit test coverage for `extract_outputs` that exercises the actual go-output document shapes (horizontal statistics, vertical statistics, no-changes text object, and multi-line property details), plus an integration assertion that changed plans report a non-zero `change-count`.
 
 ### Fixed
+- **Action Zero-Change Outputs**: Fixed `extract_outputs` in `action.sh` and `action_simplified.sh` reading the metadata file with the wrong schema (`.statistics.total`). The file written by `strata plan summary --file-format json` is go-output's rendered document (a "Summary Statistics" section), not the internal `PlanSummary` object, so changed plans wrongly reported `has-changes=false`, `change-count=0`, `has-dangers=false`, and `danger-count=0`. The action now parses the `Summary Statistics` section (horizontal and vertical layouts), reads the file directly with jq instead of round-tripping through a shell variable, and guards against non-numeric results.
+- **Action Integration Output Validation**: Corrected the integration test's required-output check to match the heredoc-style `summary<<` output and to assert that changed scenarios produce a non-zero `change-count`.
 - **Version Command Default Output Format**: Treat an empty output format as the default (`table`) in the `version` command so it renders table output when invoked without an explicit `--output` flag, instead of returning an "unsupported output format" error.
 - **Property Change Analysis**: Fixed typed nil slice values being classified as "update" instead of "remove" in change analysis, ensuring list property removals are correctly detected regardless of Go nil representation.
 - **Action Command Construction Safety**: Updated `run_analysis` in `action.sh` to build and execute the Strata command as a Bash array (`"${cmd[@]}"`) and pass `--` before the plan file path, preventing argument splitting issues and option ambiguity for user-supplied paths.

--- a/action.sh
+++ b/action.sh
@@ -429,17 +429,42 @@ extract_outputs() {
     return
   fi
 
-  local json
-  if ! json=$(cat "$json_file" 2>/dev/null); then
+  if [[ ! -r "$json_file" ]]; then
     echo "⚠️ Failed to read JSON file, setting default outputs"
     set_default_outputs
     return
   fi
 
-  # Extract statistics safely (current schema keys with fallback to legacy keys)
+  # The file written by `strata plan summary --file ... --file-format json` is
+  # go-output's rendered document, NOT the internal PlanSummary schema. It is
+  # either:
+  #   - an array of table sections; the "Summary Statistics" section carries the
+  #     counts as data[0] keyed "Total Changes"/"High Risk" (horizontal layout)
+  #     or as {Metric,Value} rows (vertical layout), or
+  #   - a single text object {"content":"No changes detected","type":"text"}.
+  # Read the "Summary Statistics" section, supporting both layouts, and default
+  # to 0 when no statistics section is present (e.g. the no-changes document).
+  #
+  # jq reads the file directly rather than via `echo "$var"`: round-tripping the
+  # payload through a shell variable is fragile with shells whose `echo`
+  # interprets backslash escapes (the file contains multi-line, escaped property
+  # "details" strings), and passing the path straight to jq avoids that risk.
+  # shellcheck disable=SC2016  # $m and jq fields are jq variables, not shell.
+  local stats_metric='
+    if type=="array" then
+      ((map(select(.title=="Summary Statistics"))[0].data) // [])
+      | (if (length>0 and (.[0]|has("Metric")))
+        then (map(select(.Metric==$m))[0].Value)
+        else .[0][$m]
+        end) // 0
+    else 0 end'
   local total_changes danger_changes
-  total_changes=$(echo "$json" | jq -r '.statistics.total // .statistics.total_changes // 0' 2>/dev/null || echo "0")
-  danger_changes=$(echo "$json" | jq -r '.statistics.high_risk // .statistics.dangerous_changes // 0' 2>/dev/null || echo "0")
+  total_changes=$(jq -r --arg m "Total Changes" "$stats_metric" "$json_file" 2>/dev/null || echo "0")
+  danger_changes=$(jq -r --arg m "High Risk" "$stats_metric" "$json_file" 2>/dev/null || echo "0")
+
+  # Guard against null/empty/non-numeric results before integer comparison.
+  [[ "$total_changes" =~ ^[0-9]+$ ]] || total_changes=0
+  [[ "$danger_changes" =~ ^[0-9]+$ ]] || danger_changes=0
 
   # Set GitHub Action outputs
   if [[ -n "${GITHUB_OUTPUT:-}" ]]; then

--- a/action_simplified.sh
+++ b/action_simplified.sh
@@ -316,14 +316,33 @@ extract_outputs() {
     return 1
   fi
 
-  local json
-  json=$(cat "$json_file")
-
-  # Extract statistics using jq (pre-installed on GitHub runners)
+  # The file written by `strata plan summary --file ... --file-format json` is
+  # go-output's rendered document, NOT the internal PlanSummary schema. It is
+  # either an array of table sections (the "Summary Statistics" section carries
+  # the counts keyed "Total Changes"/"High Risk" horizontally, or as {Metric,
+  # Value} rows when vertical), or a single text object for no changes. Read the
+  # "Summary Statistics" section supporting both layouts; default to 0.
+  #
+  # jq reads the file directly rather than via `echo "$var"`: passing the path
+  # straight to jq avoids fragile shell round-tripping of the escaped, multi-line
+  # property "details" strings the file can contain.
+  # shellcheck disable=SC2016  # $m and jq fields are jq variables, not shell.
+  local stats_metric='
+    if type=="array" then
+      ((map(select(.title=="Summary Statistics"))[0].data) // [])
+      | (if (length>0 and (.[0]|has("Metric")))
+        then (map(select(.Metric==$m))[0].Value)
+        else .[0][$m]
+        end) // 0
+    else 0 end'
   local total
   local dangers
-  total=$(echo "$json" | jq -r '.statistics.total_changes // 0')
-  dangers=$(echo "$json" | jq -r '.statistics.dangerous_changes // 0')
+  total=$(jq -r --arg m "Total Changes" "$stats_metric" "$json_file" 2>/dev/null || echo "0")
+  dangers=$(jq -r --arg m "High Risk" "$stats_metric" "$json_file" 2>/dev/null || echo "0")
+
+  # Guard against null/empty/non-numeric results before integer comparison.
+  [[ "$total" =~ ^[0-9]+$ ]] || total=0
+  [[ "$dangers" =~ ^[0-9]+$ ]] || dangers=0
 
   # Set GitHub Action outputs
   if [[ -n "${GITHUB_OUTPUT:-}" ]]; then

--- a/test/action_test.sh
+++ b/test/action_test.sh
@@ -780,6 +780,123 @@ EOF
     fi
 }
 
+# Regression test for T-1118: extract_outputs must read the go-output document
+# that `strata plan summary --file ... --file-format json` actually produces.
+# That file is a rendered table-document ARRAY (a "Summary Statistics" section),
+# NOT the internal PlanSummary schema with a top-level `.statistics` object.
+# The old code parsed `.statistics.total`, which fails on an array and silently
+# falls back to 0 — so a plan WITH changes wrongly reported change-count=0.
+test_extract_outputs_go_output_array() {
+    log_test "extract_outputs parses go-output document (T-1118)"
+
+    local run_dir="$TEST_DIR/extract_outputs_go_output"
+    local harness="$run_dir/harness.sh"
+    mkdir -p "$run_dir"
+
+    # The harness sources the real extract_outputs + set_default_outputs from
+    # action.sh, then runs extract_outputs against a JSON file matching the
+    # actual go-output shape passed as $2. It echoes the resulting GITHUB_OUTPUT.
+    cat > "$harness" <<'EOF'
+#!/bin/bash
+set -uo pipefail
+
+ACTION_PATH="$1"
+JSON_FILE="$2"
+
+GITHUB_OUTPUT="$(mktemp)"
+export GITHUB_OUTPUT
+DISPLAY_OUTPUT="display"
+OUTPUTS_WRITTEN=false
+
+eval "$(sed -n '/^set_default_outputs()/,/^}/p' "$ACTION_PATH")"
+eval "$(sed -n '/^extract_outputs()/,/^}/p' "$ACTION_PATH")"
+
+extract_outputs "$JSON_FILE"
+grep -E '^(has-changes|has-dangers|change-count|danger-count)=' "$GITHUB_OUTPUT"
+rm -f "$GITHUB_OUTPUT"
+EOF
+    chmod +x "$harness"
+
+    # Case 1: plan WITH changes, horizontal (default) statistics layout.
+    # This is the real go-output array shape; old code reported 0.
+    local horizontal_json="$run_dir/horizontal.json"
+    cat > "$horizontal_json" <<'EOF'
+[
+  {
+    "title": "Plan Information",
+    "data": [{"Plan File": "samples/web-sample.json", "Version": "1.6.2"}]
+  },
+  {
+    "title": "Summary Statistics",
+    "data": [{"Total Changes": 7, "Added": 2, "Removed": 1, "Modified": 2, "Replacements": 2, "High Risk": 2, "Unmodified": 0}]
+  },
+  {
+    "title": "Resource Changes",
+    "data": []
+  }
+]
+EOF
+    local result
+    result=$(bash "$harness" "action.sh" "$horizontal_json")
+    assert_equals "true" "$(echo "$result" | grep '^has-changes=' | cut -d= -f2)" "horizontal: has-changes=true for changed plan"
+    assert_equals "7" "$(echo "$result" | grep '^change-count=' | cut -d= -f2)" "horizontal: change-count=7"
+    assert_equals "true" "$(echo "$result" | grep '^has-dangers=' | cut -d= -f2)" "horizontal: has-dangers=true"
+    assert_equals "2" "$(echo "$result" | grep '^danger-count=' | cut -d= -f2)" "horizontal: danger-count=2"
+
+    # Case 2: vertical statistics layout ({Metric, Value} rows).
+    local vertical_json="$run_dir/vertical.json"
+    cat > "$vertical_json" <<'EOF'
+[
+  {
+    "title": "Summary Statistics",
+    "data": [
+      {"Metric": "Total Changes", "Value": 4},
+      {"Metric": "Added", "Value": 1},
+      {"Metric": "High Risk", "Value": 3},
+      {"Metric": "Unmodified", "Value": 0}
+    ]
+  }
+]
+EOF
+    result=$(bash "$harness" "action.sh" "$vertical_json")
+    assert_equals "4" "$(echo "$result" | grep '^change-count=' | cut -d= -f2)" "vertical: change-count=4"
+    assert_equals "3" "$(echo "$result" | grep '^danger-count=' | cut -d= -f2)" "vertical: danger-count=3"
+
+    # Case 3: no-changes document is a single text object, not an array.
+    local nochange_json="$run_dir/nochange.json"
+    cat > "$nochange_json" <<'EOF'
+{"content": "No changes detected", "type": "text"}
+EOF
+    result=$(bash "$harness" "action.sh" "$nochange_json")
+    assert_equals "false" "$(echo "$result" | grep '^has-changes=' | cut -d= -f2)" "no-changes: has-changes=false"
+    assert_equals "0" "$(echo "$result" | grep '^change-count=' | cut -d= -f2)" "no-changes: change-count=0"
+    assert_equals "0" "$(echo "$result" | grep '^danger-count=' | cut -d= -f2)" "no-changes: danger-count=0"
+
+    # Case 4: --details=true embeds multi-line, escaped "details" strings in the
+    # Resource Changes section. extract_outputs must still find the statistics
+    # counts and not choke on that content (it reads the file directly rather
+    # than round-tripping the payload through a shell variable).
+    local details_json="$run_dir/details.json"
+    cat > "$details_json" <<'EOF'
+[
+  {
+    "title": "Summary Statistics",
+    "data": [{"Total Changes": 4, "High Risk": 2, "Added": 1, "Removed": 0, "Modified": 2, "Replacements": 1, "Unmodified": 0}]
+  },
+  {
+    "title": "Resource Changes",
+    "data": [
+      {"Address": "aws_db_instance.main", "details": "  ~ tags {\n    ~ Environment = \"staging\" -> \"production\"\n  }\n  ~ username = \"a\" -> \"b\""}
+    ]
+  }
+]
+EOF
+    result=$(bash "$harness" "action.sh" "$details_json")
+    assert_equals "true" "$(echo "$result" | grep '^has-changes=' | cut -d= -f2)" "details: has-changes=true despite multi-line details"
+    assert_equals "4" "$(echo "$result" | grep '^change-count=' | cut -d= -f2)" "details: change-count=4"
+    assert_equals "2" "$(echo "$result" | grep '^danger-count=' | cut -d= -f2)" "details: danger-count=2"
+}
+
 # Regression test for T-1226: test scripts must start with a valid shebang.
 # A corrupted shebang (e.g. "#\!/bin/bash" with an escaped bang) makes the
 # kernel reject direct execution with "exec format error" on Linux, even
@@ -829,6 +946,7 @@ test_github_context
 test_dual_output_functions
 test_run_analysis_argument_safety
 test_latest_cache_version_validation
+test_extract_outputs_go_output_array
 test_script_shebangs
 
 # Print test summary

--- a/test/integration_test.sh
+++ b/test/integration_test.sh
@@ -249,8 +249,9 @@ test_action_scenario() {
         
         # Validate outputs
         if [ -f "$GITHUB_OUTPUT" ]; then
-            # Check that required outputs are present
-            if grep -q "summary=" "$GITHUB_OUTPUT" && \
+            # Check that required outputs are present. The "summary" output is
+            # written as a heredoc (summary<<delim), so match "=" or "<<".
+            if grep -Eq "^summary(=|<<)" "$GITHUB_OUTPUT" && \
                grep -q "has-changes=" "$GITHUB_OUTPUT" && \
                grep -q "has-dangers=" "$GITHUB_OUTPUT" && \
                grep -q "change-count=" "$GITHUB_OUTPUT" && \
@@ -258,6 +259,19 @@ test_action_scenario() {
                 log_pass "$test_name - All required outputs present"
             else
                 log_fail "$test_name - Missing required outputs"
+                echo "Output file contents:"
+                cat "$GITHUB_OUTPUT"
+            fi
+
+            # T-1118: every integration scenario plans real resource changes, so
+            # change-count must be > 0. Before the fix the action parsed the wrong
+            # JSON schema and reported change-count=0 here.
+            local change_count
+            change_count=$(grep -E "^change-count=" "$GITHUB_OUTPUT" | head -1 | cut -d= -f2)
+            if [ -n "$change_count" ] && [ "$change_count" -gt 0 ] 2>/dev/null; then
+                log_pass "$test_name - change-count is non-zero ($change_count)"
+            else
+                log_fail "$test_name - change-count should be non-zero for a changed plan (got '${change_count:-unset}')"
                 echo "Output file contents:"
                 cat "$GITHUB_OUTPUT"
             fi


### PR DESCRIPTION
## Summary

Fixes T-1118. The composite GitHub Action reported `has-changes=false`, `change-count=0`, `has-dangers=false`, and `danger-count=0` for plans that contain changes, breaking downstream workflows that gate on those outputs.

## Root cause

`extract_outputs` parsed the metadata file against the wrong schema. It read `.statistics.total` / `.statistics.high_risk`, but the file written by `strata plan summary --file ... --file-format json` is go-output's rendered document, not the internal `PlanSummary` object. It is either:

- an array of table sections, where the `Summary Statistics` section carries the counts as `data[0]` keyed `Total Changes`/`High Risk` (horizontal layout) or as `{Metric, Value}` rows (vertical layout), or
- a single text object `{"content":"No changes detected","type":"text"}` for no changes.

Indexing the array with a string key fails in jq; the error was swallowed and the `// 0` fallback produced zero counts for every changed plan.

The pre-existing unit tests masked the bug by feeding `extract_outputs` a fabricated `{"statistics":{"total_changes":N}}` object that Strata never produces.

## Fix

- `action.sh` / `action_simplified.sh`: parse the `Summary Statistics` section, supporting both the horizontal and vertical layouts and defaulting to 0 for the no-changes text object. jq reads the file directly instead of round-tripping the payload through a shell variable (avoids fragile escape handling for multi-line `details` strings), and non-numeric results are guarded before integer comparison.
- `test/action_test.sh`: added `test_extract_outputs_go_output_array`, which sources the real `extract_outputs` and asserts correct counts for horizontal, vertical, no-changes, and multi-line `details` shapes.
- `test/integration_test.sh`: fixed the required-output check to match the heredoc-style `summary<<` output (it previously grepped for `summary=`, which never matched and masked output problems), and added an assertion that changed scenarios report a non-zero `change-count`.

## Verification

- `make test-action-unit`: 55 passed, 0 failed.
- `make test-action-integration`: all output-validation scenarios pass (Basic 3, Show details 3, Danger detection 5, Complex 4 changes). The only remaining failure is the Binary caching scenario, which is environmental (GitHub release download is rate-limited / network-restricted in this sandbox) and unrelated to this change.
- End-to-end against `samples/web-sample.json` (change-count=7, danger-count=2) and `samples/danger-sample.json` (change-count=4, danger-count=2) through the real `action.sh` path.
- `bash -n` and `shellcheck` clean (no new findings).

No Go code changed.