### PR TITLE
Fix T-1202: Wire highlight-dangers GitHub Action input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Action `highlight-dangers` Input**: Added the documented `highlight-dangers` input to the GitHub Action (`action.yml`) with the matching `INPUT_HIGHLIGHT_DANGERS` env mapping, plus a unit test asserting `run_analysis` forwards `--highlight-dangers=true|false` (defaulting to `true`).
 - **Action Argument Safety Regression Tests**: Added unit test coverage for `run_analysis` to validate safe argument handling for plan/config paths containing spaces and for plan files starting with `-`.
 - **Action Output Extraction Regression Tests**: Added unit test coverage for `extract_outputs` that exercises the actual go-output document shapes (horizontal statistics, vertical statistics, no-changes text object, and multi-line property details), plus an integration assertion that changed plans report a non-zero `change-count`.
 
 ### Fixed
+- **Action Ignored Documented `highlight-dangers` Input**: The GitHub Action advertised a `highlight-dangers` input in the README and `docs/github-action.md`, but `action.yml` defined no such input and `action.sh` never forwarded it, so workflows could not disable danger highlighting. `run_analysis` now forwards `--highlight-dangers=true|false` from `INPUT_HIGHLIGHT_DANGERS`, keeping highlighting on by default.
 - **Action Zero-Change Outputs**: Fixed `extract_outputs` in `action.sh` and `action_simplified.sh` reading the metadata file with the wrong schema (`.statistics.total`). The file written by `strata plan summary --file-format json` is go-output's rendered document (a "Summary Statistics" section), not the internal `PlanSummary` object, so changed plans wrongly reported `has-changes=false`, `change-count=0`, `has-dangers=false`, and `danger-count=0`. The action now parses the `Summary Statistics` section (horizontal and vertical layouts), reads the file directly with jq instead of round-tripping through a shell variable, and guards against non-numeric results.
 - **Action Integration Output Validation**: Corrected the integration test's required-output check to match the heredoc-style `summary<<` output and to assert that changed scenarios produce a non-zero `change-count`.
 - **Version Command Default Output Format**: Treat an empty output format as the default (`table`) in the `version` command so it renders table output when invoked without an explicit `--output` flag, instead of returning an "unsupported output format" error.

--- a/action.sh
+++ b/action.sh
@@ -373,6 +373,9 @@ run_analysis() {
 
   [[ "${INPUT_SHOW_DETAILS:-false}" == "true" ]] && cmd+=("--details=true") || cmd+=("--details=false")
   [[ "${INPUT_EXPAND_ALL:-false}" == "true" ]] && cmd+=("--expand-all=true") || cmd+=("--expand-all=false")
+  # strata's --highlight-dangers flag defaults to true; only forward false when the
+  # documented action input explicitly disables danger highlighting.
+  [[ "${INPUT_HIGHLIGHT_DANGERS:-true}" == "false" ]] && cmd+=("--highlight-dangers=false") || cmd+=("--highlight-dangers=true")
   [[ -n "${INPUT_CONFIG_FILE:-}" ]] && cmd+=("--config" "$INPUT_CONFIG_FILE")
 
   cmd+=("--" "$INPUT_PLAN_FILE")

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,10 @@ inputs:
     description: 'Expand all collapsible sections in the output'
     required: false
     default: 'false'
+  highlight-dangers:
+    description: 'Highlight potentially dangerous changes'
+    required: false
+    default: 'true'
   github-token:
     description: 'GitHub token for PR comments'
     required: false
@@ -90,6 +94,7 @@ runs:
         INPUT_CONFIG_FILE: ${{ inputs.config-file }}
         INPUT_SHOW_DETAILS: ${{ inputs.show-details }}
         INPUT_EXPAND_ALL: ${{ inputs.expand-all }}
+        INPUT_HIGHLIGHT_DANGERS: ${{ inputs.highlight-dangers }}
         INPUT_GITHUB_TOKEN: ${{ inputs.github-token }}
         INPUT_COMMENT_ON_PR: ${{ inputs.comment-on-pr }}
         INPUT_UPDATE_COMMENT: ${{ inputs.update-comment }}

--- a/test/action_test.sh
+++ b/test/action_test.sh
@@ -613,6 +613,7 @@ while [[ $# -gt 0 ]]; do
     --file) json_file="$2"; shift 2 ;;
     --file-format) shift 2 ;;
     --details|--details=*|--expand-all|--expand-all=*) shift ;;
+    --highlight-dangers|--highlight-dangers=*) shift ;;
     --config) config_file="$2"; shift 2 ;;
     --) saw_separator="true"; shift; plan_file="$1"; shift ;;
     *) echo "unexpected-arg:$1" >&2; exit 99 ;;
@@ -671,6 +672,114 @@ EOF
         TESTS_PASSED=$((TESTS_PASSED + 1))
     else
         echo -e "${RED}[FAIL]${NC} run_analysis should handle plan paths that start with '-'"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+}
+
+# Regression test for T-1202: the documented `highlight-dangers` action input
+# must reach strata. run_analysis must forward --highlight-dangers=true|false
+# based on INPUT_HIGHLIGHT_DANGERS, defaulting to true when the input is unset
+# so danger highlighting stays on by default.
+test_run_analysis_highlight_dangers_wiring() {
+    log_test "run_analysis highlight-dangers wiring (T-1202)"
+
+    local run_dir="$TEST_DIR/run_analysis_highlight_dangers"
+    local temp_dir="$run_dir/temp"
+    local harness="$run_dir/highlight_dangers_harness.sh"
+    mkdir -p "$temp_dir"
+
+    # The harness sources run_analysis from action.sh with a mock strata that
+    # records the --highlight-dangers value it received, then asserts it matches
+    # the expected value derived from INPUT_HIGHLIGHT_DANGERS.
+    cat > "$harness" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+
+ACTION_PATH="$1"
+TEST_TEMP_DIR="$2"
+INPUT_VALUE="$3"
+EXPECTED_FLAG="$4"
+
+cat > "$TEST_TEMP_DIR/strata" <<'MOCK'
+#!/bin/bash
+set -euo pipefail
+
+json_file=""
+highlight_flag="<unset>"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    plan|summary) shift ;;
+    --output) shift 2 ;;
+    --file) json_file="$2"; shift 2 ;;
+    --file-format) shift 2 ;;
+    --details|--details=*|--expand-all|--expand-all=*) shift ;;
+    --highlight-dangers=*) highlight_flag="${1#--highlight-dangers=}"; shift ;;
+    --highlight-dangers) highlight_flag="$2"; shift 2 ;;
+    --config) shift 2 ;;
+    --) shift; shift ;;
+    *) echo "unexpected-arg:$1" >&2; exit 99 ;;
+  esac
+done
+
+[[ "$highlight_flag" == "$EXPECTED_FLAG" ]] || {
+  echo "highlight-dangers mismatch: got '$highlight_flag', expected '$EXPECTED_FLAG'" >&2
+  exit 95
+}
+
+cat > "$json_file" <<'JSON'
+{"statistics":{"total_changes":1,"dangerous_changes":0}}
+JSON
+echo "ok"
+MOCK
+chmod +x "$TEST_TEMP_DIR/strata"
+
+export EXPECTED_FLAG
+TEMP_DIR="$TEST_TEMP_DIR"
+STRATA_BIN="$TEST_TEMP_DIR/strata"
+INPUT_PLAN_FILE="$TEST_TEMP_DIR/plan.tfplan"
+echo "plan" > "$INPUT_PLAN_FILE"
+INPUT_OUTPUT_FORMAT="markdown"
+INPUT_SHOW_DETAILS="false"
+INPUT_EXPAND_ALL="false"
+INPUT_CONFIG_FILE=""
+if [[ "$INPUT_VALUE" != "<unset>" ]]; then
+  INPUT_HIGHLIGHT_DANGERS="$INPUT_VALUE"
+fi
+
+extract_outputs() { :; }
+set_default_outputs() { :; }
+
+eval "$(sed -n '/^run_analysis()/,/^}/p' "$ACTION_PATH")"
+run_analysis
+EOF
+    chmod +x "$harness"
+
+    # Default (input unset) must keep highlighting on.
+    if bash "$harness" "action.sh" "$temp_dir" "<unset>" "true" >/dev/null 2>&1; then
+        echo -e "${GREEN}[PASS]${NC} run_analysis defaults highlight-dangers to true"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        echo -e "${RED}[FAIL]${NC} run_analysis defaults highlight-dangers to true"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+
+    # Explicit true must forward --highlight-dangers=true.
+    if bash "$harness" "action.sh" "$temp_dir" "true" "true" >/dev/null 2>&1; then
+        echo -e "${GREEN}[PASS]${NC} run_analysis forwards highlight-dangers=true"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        echo -e "${RED}[FAIL]${NC} run_analysis forwards highlight-dangers=true"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+
+    # Explicit false must forward --highlight-dangers=false so danger
+    # highlighting can be disabled via the documented input.
+    if bash "$harness" "action.sh" "$temp_dir" "false" "false" >/dev/null 2>&1; then
+        echo -e "${GREEN}[PASS]${NC} run_analysis forwards highlight-dangers=false"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        echo -e "${RED}[FAIL]${NC} run_analysis forwards highlight-dangers=false"
         TESTS_FAILED=$((TESTS_FAILED + 1))
     fi
 }
@@ -945,6 +1054,7 @@ test_environment_variables
 test_github_context
 test_dual_output_functions
 test_run_analysis_argument_safety
+test_run_analysis_highlight_dangers_wiring
 test_latest_cache_version_validation
 test_extract_outputs_go_output_array
 test_script_shebangs


### PR DESCRIPTION
## Summary

Fixes T-1202. The GitHub Action documented a `highlight-dangers` input (README.md, docs/github-action.md) with default `true`, but the composite action could not accept or apply it: `action.yml` had no such input and `action.sh` never forwarded a danger-highlighting flag. Workflows setting `highlight-dangers: false` were silently ignored.

## Root cause

The action surface (`action.yml` + `action.sh`) was never wired for the documented input. The strata CLI already exposes a real `--highlight-dangers` flag (default `true`, `cmd/plan_summary.go`), so the gap was confined to the action layer.

## Fix

- `action.yml`: add the `highlight-dangers` input (default `'true'`) and the `INPUT_HIGHLIGHT_DANGERS` env mapping.
- `action.sh`: `run_analysis` now forwards `--highlight-dangers=true|false` from `INPUT_HIGHLIGHT_DANGERS`, defaulting to `true` so highlighting stays on by default. Mirrors the existing `--details`/`--expand-all` handling.
- `test/action_test.sh`: add `test_run_analysis_highlight_dangers_wiring` asserting unset/`true` forward `--highlight-dangers=true` and `false` forwards `--highlight-dangers=false`; update the argument-safety mock to accept the new flag.
- `CHANGELOG.md`: Fixed + Added entries.

The existing docs already described this input correctly, so no doc edits were needed for consistency — the implementation now matches the docs. T-1096 (cache logic) and T-1118 (extract_outputs) in `action.sh` are left intact.

## Validation

- `make test-action-unit` — 58 passed, 0 failed (new wiring test included)
- `make test-action-integration` — 23 passed, 0 failed
- `bash -n action.sh` — OK; `shellcheck action.sh` — no new findings (pre-existing warnings only, none on changed lines)
- `go vet ./...`, `go test ./...`, `gofmt -l .` — clean
- End-to-end: `strata plan summary --highlight-dangers=true samples/danger-sample.json` shows 2 danger annotations; `--highlight-dangers=false` shows 0. Verified `INPUT_HIGHLIGHT_DANGERS=false` propagates to `--highlight-dangers=false` through `run_analysis`.