### PR TITLE
Fix T-1348 & T-1355: mask sensitive array removals and size changes

### DIFF
--- a/lib/plan/analyzer.go
+++ b/lib/plan/analyzer.go
@@ -61,6 +61,35 @@ func (a *Analyzer) maskSensitiveValue(value any, isSensitive bool) any {
 	return sensitiveValue // "(sensitive value)" constant already defined
 }
 
+// sensitiveSubtreeHasMarker reports whether a Terraform sensitivity subtree
+// contains any sensitive marker. Terraform may express sensitivity as a single
+// bool at a path, or as a structure (slice/map) with per-element bool markers.
+// The path-based isSensitive helper only returns true for a bool at the path,
+// so aggregate slice/map handling must use this to detect per-element
+// sensitivity (e.g. before_sensitive: {"secrets": [true, true]}).
+func sensitiveSubtreeHasMarker(sensitiveValues any) bool {
+	switch v := sensitiveValues.(type) {
+	case bool:
+		return v
+	case []any:
+		for _, child := range v {
+			if sensitiveSubtreeHasMarker(child) {
+				return true
+			}
+		}
+		return false
+	case map[string]any:
+		for _, child := range v {
+			if sensitiveSubtreeHasMarker(child) {
+				return true
+			}
+		}
+		return false
+	default:
+		return false
+	}
+}
+
 // compareObjects performs deep object comparison for property change extraction with optional replacement path checking
 func (a *Analyzer) compareObjects(path string, before, after, beforeSensitive, afterSensitive any, afterUnknown any, replacePathStrings []string, analysis *PropertyChangeAnalysis) {
 	// Check if this property is unknown and handle it first (requirement 1.6)
@@ -373,7 +402,18 @@ func (a *Analyzer) compareObjects(path string, before, after, beforeSensitive, a
 				return
 			}
 
-			displayAfter := after
+			// Aggregate slice changes carry the whole slice in a single
+			// PropertyChange, so per-element sensitivity markers at the parent
+			// path must be honoured here (isSensitive only sees a bool at the
+			// path). Treat any sensitive child marker as making the aggregate
+			// sensitive, and mask the aggregate before/after value (T-1348).
+			aggregateSensitive := isSensitive ||
+				sensitiveSubtreeHasMarker(beforeSensitive) ||
+				sensitiveSubtreeHasMarker(afterSensitive)
+			aggregateBefore := a.maskSensitiveValue(before, aggregateSensitive)
+			aggregateAfter := a.maskSensitiveValue(after, aggregateSensitive)
+
+			displayAfter := aggregateAfter
 			unknownType := ""
 			if isUnknown {
 				displayAfter = a.getUnknownValueDisplay()
@@ -383,11 +423,11 @@ func (a *Analyzer) compareObjects(path string, before, after, beforeSensitive, a
 			analysis.Changes = append(analysis.Changes, PropertyChange{
 				Name:                a.extractPropertyName(path),
 				Path:                propertyPath,
-				Before:              before,
+				Before:              aggregateBefore,
 				After:               displayAfter,
 				Action:              action,
 				TriggersReplacement: triggersReplacement,
-				Sensitive:           isSensitive,
+				Sensitive:           aggregateSensitive,
 				IsUnknown:           isUnknown,
 				UnknownType:         unknownType,
 			})
@@ -402,8 +442,19 @@ func (a *Analyzer) compareObjects(path string, before, after, beforeSensitive, a
 				triggersReplacement = a.pathMatchesReplacePathString(propertyPath, replacePathStrings)
 			}
 
+			// Aggregate slice changes carry the whole slice in a single
+			// PropertyChange, so per-element sensitivity markers at the parent
+			// path must be honoured here (isSensitive only sees a bool at the
+			// path). Treat any sensitive child marker as making the aggregate
+			// sensitive, and mask both sides before appending (T-1355).
+			aggregateSensitive := isSensitive ||
+				sensitiveSubtreeHasMarker(beforeSensitive) ||
+				sensitiveSubtreeHasMarker(afterSensitive)
+			aggregateBefore := a.maskSensitiveValue(before, aggregateSensitive)
+			aggregateAfter := a.maskSensitiveValue(after, aggregateSensitive)
+
 			// Handle unknown values for array size changes (requirement 1.6)
-			displayAfter := after
+			displayAfter := aggregateAfter
 			unknownType := ""
 			if isUnknown {
 				displayAfter = a.getUnknownValueDisplay()
@@ -413,10 +464,11 @@ func (a *Analyzer) compareObjects(path string, before, after, beforeSensitive, a
 			analysis.Changes = append(analysis.Changes, PropertyChange{
 				Name:                a.extractPropertyName(path),
 				Path:                propertyPath,
-				Before:              before,
+				Before:              aggregateBefore,
 				After:               displayAfter,
 				Action:              "update",
 				TriggersReplacement: triggersReplacement,
+				Sensitive:           aggregateSensitive,
 				IsUnknown:           isUnknown,
 				UnknownType:         unknownType,
 			})

--- a/lib/plan/sensitive_array_leak_test.go
+++ b/lib/plan/sensitive_array_leak_test.go
@@ -1,0 +1,89 @@
+package plan
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestSensitiveArrayRemovalLeak verifies that when a slice is removed and
+// Terraform reports per-element sensitivity (e.g. before_sensitive:
+// {"secrets": [true, true]}), the aggregate removal change is marked sensitive
+// and the removed values are masked rather than leaked via PropertyChange.Before.
+//
+// Regression test for T-1348.
+func TestSensitiveArrayRemovalLeak(t *testing.T) {
+	analyzer := &Analyzer{}
+	analysis := &PropertyChangeAnalysis{Changes: []PropertyChange{}}
+
+	before := map[string]any{"secrets": []any{"old-secret-1", "old-secret-2"}}
+	after := map[string]any{}
+	beforeSensitive := map[string]any{"secrets": []any{true, true}}
+
+	analyzer.compareObjects("", before, after, beforeSensitive, nil, nil, nil, analysis)
+
+	if assert.Len(t, analysis.Changes, 1, "expected a single aggregate removal change") {
+		assert.True(t, analysis.Changes[0].Sensitive, "removal of a per-element sensitive array should be marked sensitive")
+		assert.NotContains(t, fmt.Sprint(analysis.Changes[0].Before), "old-secret", "removed secret values must be masked")
+	}
+}
+
+// TestSensitiveArraySizeChangeLeak verifies that when an array changes size and
+// Terraform reports per-element sensitivity, the aggregate size-change record is
+// marked sensitive and both before and after values are masked.
+//
+// Regression test for T-1355.
+func TestSensitiveArraySizeChangeLeak(t *testing.T) {
+	analyzer := &Analyzer{}
+	analysis := &PropertyChangeAnalysis{Changes: []PropertyChange{}}
+
+	before := map[string]any{"secrets": []any{"old-secret-1", "old-secret-2"}}
+	after := map[string]any{"secrets": []any{"new-secret-1"}}
+	beforeSensitive := map[string]any{"secrets": []any{true, true}}
+	afterSensitive := map[string]any{"secrets": []any{true}}
+
+	analyzer.compareObjects("", before, after, beforeSensitive, afterSensitive, nil, nil, analysis)
+
+	if assert.Len(t, analysis.Changes, 1, "expected a single aggregate size-change record") {
+		assert.True(t, analysis.Changes[0].Sensitive, "size change of a per-element sensitive array should be marked sensitive")
+		assert.NotContains(t, fmt.Sprint(analysis.Changes[0].Before), "old-secret", "before secret values must be masked")
+		assert.NotContains(t, fmt.Sprint(analysis.Changes[0].After), "new-secret", "after secret values must be masked")
+	}
+}
+
+// TestNonSensitiveArrayShowsValues is a control ensuring the fix does not
+// regress non-sensitive arrays: real values must still be shown for both the
+// removal and size-change aggregate sub-cases.
+func TestNonSensitiveArrayShowsValues(t *testing.T) {
+	analyzer := &Analyzer{}
+
+	t.Run("non-sensitive removal shows real values", func(t *testing.T) {
+		analysis := &PropertyChangeAnalysis{Changes: []PropertyChange{}}
+
+		before := map[string]any{"items": []any{"value-1", "value-2"}}
+		after := map[string]any{}
+
+		analyzer.compareObjects("", before, after, nil, nil, nil, nil, analysis)
+
+		if assert.Len(t, analysis.Changes, 1, "expected a single aggregate removal change") {
+			assert.False(t, analysis.Changes[0].Sensitive, "non-sensitive removal should not be marked sensitive")
+			assert.Contains(t, fmt.Sprint(analysis.Changes[0].Before), "value-1", "non-sensitive before values should be shown")
+		}
+	})
+
+	t.Run("non-sensitive size change shows real values", func(t *testing.T) {
+		analysis := &PropertyChangeAnalysis{Changes: []PropertyChange{}}
+
+		before := map[string]any{"items": []any{"value-1", "value-2"}}
+		after := map[string]any{"items": []any{"value-3"}}
+
+		analyzer.compareObjects("", before, after, nil, nil, nil, nil, analysis)
+
+		if assert.Len(t, analysis.Changes, 1, "expected a single aggregate size-change record") {
+			assert.False(t, analysis.Changes[0].Sensitive, "non-sensitive size change should not be marked sensitive")
+			assert.Contains(t, fmt.Sprint(analysis.Changes[0].Before), "value-1", "non-sensitive before values should be shown")
+			assert.Contains(t, fmt.Sprint(analysis.Changes[0].After), "value-3", "non-sensitive after values should be shown")
+		}
+	})
+}


### PR DESCRIPTION
Fixes two closely-related defects in the same `case []any` branch of `Analyzer.compareObjects` (`lib/plan/analyzer.go`) with a shared root cause.

## Bugs

- **T-1348 — Sensitive array removals leak unmasked values.** When a slice is removed (`after` nil or not a slice), the branch emitted one aggregate `PropertyChange` using the raw `Before` and `Sensitive: isSensitive`. With per-element sensitivity (e.g. `before_sensitive: {"secrets": [true, true]}`), `isSensitive(path, ...)` returns false because the parent-path value is a `[]any`, not a `bool`. The removed secret values leaked via `PropertyChange.Before` and the change was not flagged sensitive.
- **T-1355 — Sensitive array size changes leak unmasked values.** The size-change sub-case (`len(before) != len(after)`, both non-empty) emitted raw `Before`/`After` and did not set `Sensitive` at all, exposing both sides.

## Root cause

The aggregate `case []any` handling treats sensitivity as a single bool at the parent path and ignores per-element sensitivity subtrees, and it does not mask the aggregate before/after value. (The equal-length recursion path was unaffected because it recurses per element via `extractSensitiveIndex`.)

## Fix

- Add a small shared helper `sensitiveSubtreeHasMarker(any) bool` that recursively detects any sensitive marker in a sensitivity subtree (handles `bool`, `[]any`, `map[string]any`).
- In **both** the removal and size-change sub-cases, compute `aggregateSensitive = isSensitive || sensitiveSubtreeHasMarker(beforeSensitive) || sensitiveSubtreeHasMarker(afterSensitive)`, mask both before/after via the existing `maskSensitiveValue`, and set `Sensitive: aggregateSensitive`.

This reuses the masking convention established by the T-548 nested-object fix rather than inventing a new style. Non-sensitive arrays are unaffected (the helper returns false and `maskSensitiveValue` is a no-op).

## Tests

New `lib/plan/sensitive_array_leak_test.go`:
- `TestSensitiveArrayRemovalLeak` (T-1348)
- `TestSensitiveArraySizeChangeLeak` (T-1355)
- `TestNonSensitiveArrayShowsValues` — control confirming real values still shown

## Validation

- `make build`, `make fmt`, `make vet`, `make test` all pass
- `staticcheck ./...` clean
- Existing T-548 nested-leak tests still pass
- `make lint` reports only pre-existing `goconst` issues (present on `main` unchanged); no new lint issues introduced